### PR TITLE
sctp: Add SCTP Diameter PPID

### DIFF
--- a/libfdcore/sctp.c
+++ b/libfdcore/sctp.c
@@ -1108,6 +1108,9 @@ stop:
 	return 0;
 }
 
+#define FD_SCTP_UNSECURED_DIAMETER_PPID 46
+#define FD_SCTP_SECURED_DIAMETER_PPID 47
+
 /* Send a vector over a specified stream */
 ssize_t fd_sctp_sendstrv(struct cnxctx * conn, uint16_t strid, const struct iovec *iov, int iovcnt)
 {
@@ -1134,8 +1137,6 @@ ssize_t fd_sctp_sendstrv(struct cnxctx * conn, uint16_t strid, const struct iove
 	hdr = (struct cmsghdr *)anci;
 	hdr->cmsg_len   = sizeof(anci);
 	hdr->cmsg_level = IPPROTO_SCTP;
-#define FD_SCTP_UNSECURED_DIAMETER_PPID 46
-#define FD_SCTP_SECURED_DIAMETER_PPID 47
 #ifdef OLD_SCTP_SOCKET_API
 	hdr->cmsg_type  = SCTP_SNDRCV;
 	sndrcv = (struct sctp_sndrcvinfo *)CMSG_DATA(hdr);

--- a/libfdcore/sctp.c
+++ b/libfdcore/sctp.c
@@ -1134,14 +1134,24 @@ ssize_t fd_sctp_sendstrv(struct cnxctx * conn, uint16_t strid, const struct iove
 	hdr = (struct cmsghdr *)anci;
 	hdr->cmsg_len   = sizeof(anci);
 	hdr->cmsg_level = IPPROTO_SCTP;
+#define FD_SCTP_UNSECURED_DIAMETER_PPID 46
+#define FD_SCTP_SECURED_DIAMETER_PPID 47
 #ifdef OLD_SCTP_SOCKET_API
 	hdr->cmsg_type  = SCTP_SNDRCV;
 	sndrcv = (struct sctp_sndrcvinfo *)CMSG_DATA(hdr);
 	sndrcv->sinfo_stream = strid;
+	if (!fd_cnx_teststate(conn, CC_STATUS_TLS))
+		sndrcv->sinfo_ppid = htonl(FD_SCTP_UNSECURED_DIAMETER_PPID);
+	else
+		sndrcv->sinfo_ppid = htonl(FD_SCTP_SECURED_DIAMETER_PPID);
 #else /* OLD_SCTP_SOCKET_API */
 	hdr->cmsg_type  = SCTP_SNDINFO;
 	sndinf = (struct sctp_sndinfo *)CMSG_DATA(hdr);
 	sndinf->snd_sid = strid;
+	if (!fd_cnx_teststate(conn, CC_STATUS_TLS))
+		sndinf->snd_ppid = htonl(FD_SCTP_UNSECURED_DIAMETER_PPID);
+	else
+		sndinf->snd_ppid = htonl(FD_SCTP_SECURED_DIAMETER_PPID);
 #endif /* OLD_SCTP_SOCKET_API */
 	/* note : we could store other data also, for example in .sinfo_ppid for remote peer or in .sinfo_context for errors. */
 	


### PR DESCRIPTION
According to the RFC for Diameter Base Protocol:

2.1.1. SCTP Guidelines
   ...
   ...
   A Diameter agent SHOULD use dedicated payload protocol identifiers
   (PPIDs) for clear text and encrypted SCTP DATA chunks instead of only
   using the unspecified payload protocol identifier (value 0).  For
   this purpose, two PPID values are allocated: the PPID value 46 is for
   Diameter messages in clear text SCTP DATA chunks, and the PPID value
   47 is for Diameter messages in protected DTLS/SCTP DATA chunks.

So, I've added the SCTP Diameter PPID