### PR TITLE
Log debug_to_error

### DIFF
--- a/libfdcore/cnxctx.c
+++ b/libfdcore/cnxctx.c
@@ -298,7 +298,7 @@ struct cnxctx * fd_cnx_cli_connect_tcp(sSA * sa /* contains the port already */,
 	{
 		int ret = fd_tcp_client( &sock, sa, addrlen );
 		if (ret != 0) {
-			LOG_D("TCP connection to %s failed: %s", sa_buf, strerror(ret));
+			LOG_E("TCP connection to %s failed: %s", sa_buf, strerror(ret));
 			return NULL;
 		}
 	}

--- a/libfdcore/cnxctx.c
+++ b/libfdcore/cnxctx.c
@@ -298,7 +298,7 @@ struct cnxctx * fd_cnx_cli_connect_tcp(sSA * sa /* contains the port already */,
 	{
 		int ret = fd_tcp_client( &sock, sa, addrlen );
 		if (ret != 0) {
-			LOG_E("TCP connection to %s failed: %s", sa_buf, strerror(ret));
+			LOG_N("TCP connection to %s failed: %s", sa_buf, strerror(ret));
 			return NULL;
 		}
 	}


### PR DESCRIPTION
Failing to connect causes us to return NULL so the function has failed. This should have an error log