### PR TITLE
Auto-encoders for basic types

### DIFF
--- a/libfdproto/messages.c
+++ b/libfdproto/messages.c
@@ -1647,7 +1647,7 @@ int fd_msg_avp_value_encode ( void *data, struct avp *avp )
 		
 		/* Then retrieve information about the parent's type (= derived type) */
 		CHECK_FCT(  fd_dict_getdict( avp->avp_model, &dict )  );
-		fd_dict_search( dict, DICT_TYPE, TYPE_OF_AVP, avp->avp_model, &parenttype, EINVAL);
+		CHECK_FCT(  fd_dict_search( dict, DICT_TYPE, TYPE_OF_AVP, avp->avp_model, &parenttype, 0)  );
 		if (parenttype != NULL) {
 			CHECK_FCT(  fd_dict_getval(parenttype, &type_data)  );
 		}


### PR DESCRIPTION
Non-special types don't have a parenttype which caused us to throw an exception if you tried to use fd_msg_avp_value_encode on them. This adds default behaviour for those types so that fd_msg_avp_value_encode can be used for simple types.