### PR TITLE
Make libfdcore reinitializable

### DIFF
--- a/libfdcore/core.c
+++ b/libfdcore/core.c
@@ -170,8 +170,9 @@ int fd_core_initialize(void)
 {
 	int ret;
 	
-	if (core_state_get() != CORE_NOT_INIT) {
-		fprintf(stderr, "fd_core_initialize() called more than once!\n");
+	if ((core_state_get() != CORE_NOT_INIT) &&
+            (core_state_get() != CORE_TERM)) {
+		fprintf(stderr, "fd_core_initialize() called when already initialized!\n");
 		return EINVAL;
 	}
 	


### PR DESCRIPTION
It's reasonable to initialize libfdcore if it was successfully shutdown as well as if it hasn't been started before.