### PR TITLE
CA certificate list is not a certificate chain

### DIFF
--- a/libfdcore/fdd.y
+++ b/libfdcore/fdd.y
@@ -670,7 +670,7 @@ tls_ca:			TLS_CA '=' QSTRING ';'
 							{ yyerror (&yylloc, conf, "Error reading CA file."); YYERROR; } );
 							
 					CHECK_GNUTLS_DO( gnutls_x509_crt_list_import2(&calist, &cacount, &cafile, GNUTLS_X509_FMT_PEM, 
-										GNUTLS_X509_CRT_LIST_FAIL_IF_UNSORTED),
+										0),
 							{ yyerror (&yylloc, conf, "Error importing CA file."); YYERROR; } );
 					free(cafile.data);
 					


### PR DESCRIPTION
when the TLS_CA cafile contains more than one certificate this error is shown
```
19:54:18  ERROR  TLS ERROR: in 'gnutls_x509_crt_list_import2(&calist, &cacount, &cafile, GNUTLS_X509_FMT_PEM, GNUTLS_X509_CRT_LIST_FAIL_IF_UNSORTED)' : The provided X.509 certificate list is not sorted (in subject to issuer order)
```

It's caused because the cafile is treated as a certificate chain which it is not. It's a list of root CA certicates.
This is why the `GNUTLS_X509_CRT_LIST_FAIL_IF_UNSORTED` should be removed