### PR TITLE
Add support for multiple diameter connections and explicitly remove peers 

### DIFF
--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -270,6 +270,9 @@ extern const char *peer_state_str[];
 #define PI_PRST_NONE	0	/* the peer entry is deleted after disconnection / error */
 #define PI_PRST_ALWAYS	1	/* the peer entry is persistant (will be kept as ZOMBIE in case of error) */
 			
+#define PI_DIAMID_STAT	0	/* the peer's Diameter Identity is statically configured */
+#define PI_DIAMID_DYN	1	/* the peer's Diameter Identity is learnt dynamically from the CEA */
+			
 /* Information about a remote peer */
 struct peer_info {
 	
@@ -285,6 +288,7 @@ struct peer_info {
 			unsigned	sctpsec :1;	/* PI_SCTPSEC_* */
 			unsigned	exp :1;		/* PI_EXP_* */
 			unsigned	persist :1;	/* PI_PRST_* */
+			unsigned	diamid :1;	/* PI_DIAMID_* */
 			
 		}		pic_flags;	/* Flags influencing the connection to the remote peer */
 		
@@ -303,6 +307,9 @@ struct peer_info {
 		
 		/* enum peer_state	pir_state; */ 
 		/* Since 1.1.0, read the state with fd_peer_getstate(peer). */
+		
+		DiamId_t	pir_host;	/* The received host in CER/CEA. */
+		size_t		pir_hostlen;	/* length of the host */
 		
 		DiamId_t	pir_realm;	/* The received realm in CER/CEA. */
 		size_t		pir_realmlen;	/* length of the realm */
@@ -374,6 +381,22 @@ extern pthread_rwlock_t fd_g_peers_rw; /* protect the list */
  *    ENOMEM 	: Memory allocation for the new object element failed.)
  */
 int fd_peer_add ( struct peer_info * info, const char * orig_dbg, void (*cb)(struct peer_info *, void *), void * cb_data );
+
+/*
+ * FUNCTION:	fd_peer_remove
+ *
+ * PARAMETERS:
+ *  diamid 	: an UTF8 string describing the diameter Id of the peer to seek
+ *  diamidlen	: length of the diamid
+ *
+ * DESCRIPTION:
+ *  Remove a peer from the list of peers to which the daemon must maintain a connection.
+ *
+ * RETURN VALUE:
+ *  0      	: The peer is removed.
+ *  !0    	: An error occurred.
+ */
+int fd_peer_remove ( DiamId_t diamid, size_t diamidlen );
 
 /*
  * FUNCTION:	fd_peer_getbyid

--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -345,7 +345,11 @@ struct peer_hdr {
 
 /* the global list of peers. 
   Since we are not expecting so many connections, we don't use a hash, but it might be changed.
-  The list items are peer_hdr structures (actually, fd_peer, but the cast is OK) */
+  The list items are peer_hdr structures (actually, fd_peer, but the cast is OK).
+
+  There can by multiple peers with the same Diameter-Id on this list, but at most one of these
+  peers can be non-zombie peers (i.e. if there are multiple peers with the same Diameter-Id,
+  all but one of them (or all of them) should be in STATE_ZOMBIE). */
 extern struct fd_list fd_g_peers;
 extern pthread_rwlock_t fd_g_peers_rw; /* protect the list */
 
@@ -408,7 +412,10 @@ int fd_peer_remove ( DiamId_t diamid, size_t diamidlen );
  *  peer	: The peer is stored here if it exists.
  *
  * DESCRIPTION: 
- *   Search a peer by its Diameter-Id.
+ *   Search for a peer in fd_g_peers by its Diameter-Id. If there are multiple
+ *   such peers, prefer a non-zombie peer. There should be at most one
+ *   non-zombie peer. All zombie peers (with the given Diameter-Id) are treated
+ *   equally.
  *
  * RETURN VALUE:
  *  0   : *peer has been updated (to NULL if the peer is not found).

--- a/include/freeDiameter/libfdproto.h
+++ b/include/freeDiameter/libfdproto.h
@@ -2142,7 +2142,7 @@ int  fd_rtd_init(struct rt_data ** rtd);
 void fd_rtd_free(struct rt_data ** rtd);
 
 /* Add a peer to the candidates list. */
-int  fd_rtd_candidate_add(struct rt_data * rtd, DiamId_t peerid, size_t peeridlen, DiamId_t realm, size_t realmlen);
+int  fd_rtd_candidate_add(struct rt_data * rtd, DiamId_t cfg_peerid, size_t cfg_peeridlen, DiamId_t peerid, size_t peeridlen, DiamId_t realm, size_t realmlen);
 
 /* Remove a peer from the candidates (if it is found). The search is case-insensitive. */
 void fd_rtd_candidate_del(struct rt_data * rtd, uint8_t * id, size_t idsz);
@@ -2159,7 +2159,9 @@ int  fd_rtd_get_nb_attempts(struct rt_data * rtd, int * sendingattemtps);
 /* The extracted list items have the following structure: */
 struct rtd_candidate {
 	struct fd_list	chain;	/* link in the list returned by the previous fcts */
-	DiamId_t	diamid;	/* the diameter Id of the peer */
+	DiamId_t	cfg_diamid;	/* the configured diameter Id of the peer */
+	size_t		cfg_diamidlen; /* cached size of the cfg_diamid string */
+	DiamId_t	diamid;	/* the learned diameter Id of the peer */
 	size_t		diamidlen; /* cached size of the diamid string */
 	DiamId_t	realm;	/* the diameter realm of the peer */
 	size_t		realmlen; /* cached size of realm */

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -213,8 +213,14 @@ int fd_peer_remove ( DiamId_t diamid, size_t diamidlen )
 			peer->p_hdr.info.config.pic_flags.exp = PI_EXP_INACTIVE;
 			peer->p_hdr.info.config.pic_lft = 0;
 			CHECK_FCT( fd_p_expi_update(peer) );
+			found = 1;
 			break;
 		}
+	}
+
+	if (!found)
+	{
+		TRACE_ERROR("Diameter peer %*s not valid - caller is out of sync", (int)diamidlen, diamid);
 	}
 
 	CHECK_POSIX( pthread_rwlock_unlock(&fd_g_peers_rw) );

--- a/libfdcore/routing_dispatch.c
+++ b/libfdcore/routing_dispatch.c
@@ -933,11 +933,13 @@ static int msg_rt_out(struct msg * msg)
 		CHECK_FCT( pthread_rwlock_rdlock(&fd_g_activ_peers_rw) );
 		for (li = fd_g_activ_peers.next; li != &fd_g_activ_peers; li = li->next) {
 			struct fd_peer * p = (struct fd_peer *)li->o;
-			CHECK_FCT_DO( ret = fd_rtd_candidate_add(rtd, 
-							p->p_hdr.info.pi_diamid, 
-							p->p_hdr.info.pi_diamidlen, 
-							p->p_hdr.info.runtime.pir_realm,
-							p->p_hdr.info.runtime.pir_realmlen), 
+			CHECK_FCT_DO( ret = fd_rtd_candidate_add(rtd,
+								 p->p_hdr.info.pi_diamid,
+								 p->p_hdr.info.pi_diamidlen,
+								 p->p_hdr.info.runtime.pir_host,
+								 p->p_hdr.info.runtime.pir_hostlen,
+								 p->p_hdr.info.runtime.pir_realm,
+								 p->p_hdr.info.runtime.pir_realmlen),
 				{ CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_activ_peers_rw), ); return ret; } );
 		}
 		CHECK_FCT( pthread_rwlock_unlock(&fd_g_activ_peers_rw) );
@@ -1023,7 +1025,7 @@ static int msg_rt_out(struct msg * msg)
 			break;
 
 		/* Search for the peer */
-		CHECK_FCT( fd_peer_getbyid( c->diamid, c->diamidlen, 0, (void *)&peer ) );
+		CHECK_FCT( fd_peer_getbyid( c->cfg_diamid, c->cfg_diamidlen, 0, (void *)&peer ) );
 
 		if (fd_peer_getstate(peer) == STATE_OPEN) {
 			/* Send to this one */

--- a/libfdproto/rt_data.c
+++ b/libfdproto/rt_data.c
@@ -115,7 +115,7 @@ int  fd_rtd_candidate_add(struct rt_data * rtd, DiamId_t cfg_peerid, size_t cfg_
 	struct fd_list * prev;
 	struct rtd_candidate * new;
 	
-	TRACE_ENTRY("%p %p %zd %p %zd", rtd, cfg_peerid, cfded_peeridlen, peerid, peeridlen, realm, realmlen);
+	TRACE_ENTRY("%p %p %zd %p %zd", rtd, cfg_peerid, cfg_peeridlen, peerid, peeridlen, realm, realmlen);
 	CHECK_PARAMS(rtd && cfg_peerid && cfg_peeridlen && peerid && peeridlen);
 	
 	/* Since the peers are ordered when they are added (fd_g_activ_peers) we search for the position from the end -- this should be efficient */


### PR DESCRIPTION
The changes provided two things:

- The ability to connect to a Diameter realm, rather than a specific peer in a realm, which is useful if for example a realm is fronted by a Diameter Routing Agent that basically just serves as a load balancer and forwards you onto the real server as appropriate
- The ability to explicitly remove peers you're connected to