### PR TITLE
Support forcibly closing diameter connections 

### DIFF
--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -107,6 +107,8 @@ int fd_core_shutdown(void);
 /* Wait for the shutdown to be complete -- this should always be called after fd_core_shutdown */
 int fd_core_wait_shutdown_complete(void);
 
+/* Forcibly shutdown any Diameter connections */
+int fd_connections_shutdown(void);
 
 /*============================================================*/
 /*                          CONFIG                            */

--- a/libfdcore/core.c
+++ b/libfdcore/core.c
@@ -370,6 +370,9 @@ int fd_core_wait_shutdown_complete(void)
 	return 0;
 }
 
-
-
-
+/* Forcibly shut down any Diameter connections */
+int fd_connections_shutdown(void)
+{
+        LOG_N( FD_PROJECT_BINARY " Closing Diameter connections");
+        CHECK_FCT_DO( fd_peer_fini_force(), /* Stop all connections */ );
+}

--- a/libfdcore/core.c
+++ b/libfdcore/core.c
@@ -373,6 +373,6 @@ int fd_core_wait_shutdown_complete(void)
 /* Forcibly shut down any Diameter connections */
 int fd_connections_shutdown(void)
 {
-        LOG_N( FD_PROJECT_BINARY " Closing Diameter connections");
-        CHECK_FCT_DO( fd_peer_fini_force(), /* Stop all connections */ );
+	LOG_N( FD_PROJECT_BINARY " Closing Diameter connections");
+	CHECK_FCT_DO( fd_peer_fini_force(), /* Stop all connections */ );
 }

--- a/libfdcore/fdcore-internal.h
+++ b/libfdcore/fdcore-internal.h
@@ -287,6 +287,7 @@ void fd_peer_failover_msg(struct fd_peer * peer);
 /* Peer expiry */
 int fd_p_expi_init(void);
 int fd_p_expi_fini(void);
+int fd_p_expi_fini_force(void);
 int fd_p_expi_update(struct fd_peer * peer );
 
 /* Peer state machine */

--- a/libfdcore/fdcore-internal.h
+++ b/libfdcore/fdcore-internal.h
@@ -287,7 +287,6 @@ void fd_peer_failover_msg(struct fd_peer * peer);
 /* Peer expiry */
 int fd_p_expi_init(void);
 int fd_p_expi_fini(void);
-int fd_p_expi_fini_force(void);
 int fd_p_expi_update(struct fd_peer * peer );
 
 /* Peer state machine */

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -460,6 +460,13 @@ int fd_peer_fini_force()
                 }
                 CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
         }
+
+        /* Free memory objects of all peers */
+        while (!FD_IS_LIST_EMPTY(&purge)) {
+                struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
+                fd_list_unlink(&peer->p_hdr.chain);
+                fd_peer_free(&peer);
+        }
 }
 
 /* Dump info of one peer */

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -417,23 +417,23 @@ int fd_peer_fini()
 		CHECK_SYS(  clock_gettime(CLOCK_REALTIME, &now)  );
 	}
 
-        fd_peer_fini_force();
+	fd_peer_fini_force();
 
-        /* Free memory objects of all peers */
-        while (!FD_IS_LIST_EMPTY(&purge)) {
-                struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
-                fd_list_unlink(&peer->p_hdr.chain);
-                fd_peer_free(&peer);
-        }
+	/* Free memory objects of all peers */
+	while (!FD_IS_LIST_EMPTY(&purge)) {
+		struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
+		fd_list_unlink(&peer->p_hdr.chain);
+		fd_peer_free(&peer);
+	}
 
-        /* Now empty the validators list */
-        CHECK_FCT_DO( pthread_rwlock_wrlock(&validators_rw), /* continue */ );
-        while (!FD_IS_LIST_EMPTY( &validators )) {
-                struct fd_list * v = validators.next;
-                fd_list_unlink(v);
-                free(v);
-        }
-        CHECK_FCT_DO( pthread_rwlock_unlock(&validators_rw), /* continue */ );
+	/* Now empty the validators list */
+	CHECK_FCT_DO( pthread_rwlock_wrlock(&validators_rw), /* continue */ );
+	while (!FD_IS_LIST_EMPTY( &validators )) {
+		struct fd_list * v = validators.next;
+		fd_list_unlink(v);
+		free(v);
+	}
+	CHECK_FCT_DO( pthread_rwlock_unlock(&validators_rw), /* continue */ );
 	
 	return 0;
 }
@@ -441,32 +441,32 @@ int fd_peer_fini()
 /* Terminate peer module (destroy all peers forcibly) */
 int fd_peer_fini_force()
 {
-        struct fd_list * li;
-        struct fd_list purge = FD_LIST_INITIALIZER(purge); /* Store zombie peers here */
-        int list_empty;
+	struct fd_list * li;
+	struct fd_list purge = FD_LIST_INITIALIZER(purge); /* Store zombie peers here */
+	int list_empty;
 
-        CHECK_FCT_DO( pthread_rwlock_wrlock(&fd_g_peers_rw), /* continue */ );
-        list_empty = FD_IS_LIST_EMPTY(&fd_g_peers);
-        CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
+	CHECK_FCT_DO( pthread_rwlock_wrlock(&fd_g_peers_rw), /* continue */ );
+	list_empty = FD_IS_LIST_EMPTY(&fd_g_peers);
+	CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
 
-        if (!list_empty) {
-                TRACE_DEBUG(INFO, "Forcing connections shutdown");
-                CHECK_FCT_DO( pthread_rwlock_wrlock(&fd_g_peers_rw), /* continue */ );
-                while (!FD_IS_LIST_EMPTY(&fd_g_peers)) {
-                        struct fd_peer * peer = (struct fd_peer *)(fd_g_peers.next->o);
-                        fd_psm_abord(peer);
-                        fd_list_unlink(&peer->p_hdr.chain);
-                        fd_list_insert_before(&purge, &peer->p_hdr.chain);
-                }
-                CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
-        }
+	if (!list_empty) {
+		TRACE_DEBUG(INFO, "Forcing connections shutdown");
+ 		CHECK_FCT_DO( pthread_rwlock_wrlock(&fd_g_peers_rw), /* continue */ );
+		while (!FD_IS_LIST_EMPTY(&fd_g_peers)) {
+			struct fd_peer * peer = (struct fd_peer *)(fd_g_peers.next->o);
+			fd_psm_abord(peer);
+			fd_list_unlink(&peer->p_hdr.chain);
+			fd_list_insert_before(&purge, &peer->p_hdr.chain);
+		}
+		CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
+	}
 
-        /* Free memory objects of all peers */
-        while (!FD_IS_LIST_EMPTY(&purge)) {
-                struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
-                fd_list_unlink(&peer->p_hdr.chain);
-                fd_peer_free(&peer);
-        }
+	/* Free memory objects of all peers */
+	while (!FD_IS_LIST_EMPTY(&purge)) {
+		struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
+		fd_list_unlink(&peer->p_hdr.chain);
+		fd_peer_free(&peer);
+	}
 }
 
 /* Dump info of one peer */


### PR DESCRIPTION
Add support for forcibly closing all diameter connections from within the diameter stack. Peers are destroyed as in fd_peer_fini() but without doing so gently first. No calls to this new helper method are added, but is exposed as it is useful for peer cleanup. Contains some small refactoring to avoid duplicate code."