### PR TITLE
Fix misspellings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Name of the project
 PROJECT("freeDiameter")
 
-# Informations to display in daemon's help
+# Information to display in daemon's help
 SET(FD_PROJECT_NAME freeDiameter CACHE STRING "Project name")
 SET(FD_PROJECT_BINARY freeDiameterd)
 SET(FD_PROJECT_COPYRIGHT "Copyright (c) 2008-2015, WIDE Project (www.wide.ad.jp) and NICT (www.nict.go.jp)")
@@ -30,7 +30,7 @@ SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 SET(DEFAULT_CONF_PATH ${CMAKE_INSTALL_PREFIX}/etc/freeDiameter CACHE PATH "Default location of freeDiameter configuration files")
 
 IF (NOT DEFINED LIB_INSTALL_DIR)
-SET(LIB_INSTALL_DIR lib CACHE PATH "Default library path name on the system, to accomodate RPM-based systems that use lib64")
+SET(LIB_INSTALL_DIR lib CACHE PATH "Default library path name on the system, to accommodate RPM-based systems that use lib64")
 ENDIF (NOT DEFINED LIB_INSTALL_DIR)
 
 SET(INSTALL_HEADERS_SUFFIX 		include/freeDiameter 	CACHE PATH "Directory where the headers are installed (relative to CMAKE_INSTALL_PREFIX).")

--- a/INSTALL.FreeBSD
+++ b/INSTALL.FreeBSD
@@ -47,7 +47,7 @@ COMPLETE INSTRUCTIONS
 7) Run cmake for freeDiameter (add other flags as you see fit, see INSTALL for more details)
    # /usr/local/bin/cmake -DFLEX_EXECUTABLE:FILEPATH=/usr/local/bin/flex -DSCTP_USE_MAPPED_ADDRESSES:BOOL=ON ../freeDiameter
 
-8) Compile, optionnaly test
+8) Compile, optionally test
    # make
    # make test
 

--- a/INSTALL.Ubuntu
+++ b/INSTALL.Ubuntu
@@ -21,7 +21,7 @@ The following packages are required to compile freeDiameter from source:
  
 (note that libidn2 and libsctp can be avoided by defining DISABLE_SCTP and DIAMID_IDNA_REJECT)
  
-Additionnaly, these ones may be useful:
+Additionally, these ones may be useful:
  mercurial gdb
  
 Extensions additional dependencies:

--- a/contrib/OpenWRT/HOWTO
+++ b/contrib/OpenWRT/HOWTO
@@ -99,7 +99,7 @@ ssh root@192.168.1.1
 # echo "src/gz localrepo http://192.168.1.25/owrt/packages" >> /etc/opkg.conf 
 # opkg update
 
-9) Install freeDiameter, you're done. Optionnaly, install also certtool on the router before, to 
+9) Install freeDiameter, you're done. Optionally, install also certtool on the router before, to 
    generate the TLS certificate automatically.
 # opkg install freeDiameter
 

--- a/contrib/OpenWRT/test_required/testcase.c
+++ b/contrib/OpenWRT/test_required/testcase.c
@@ -14,7 +14,7 @@ static int called = 0;
 
 static void cleanupmutex(void * arg)
 {
-	printf("cancelation cleanup handler called\n");
+	printf("cancellation cleanup handler called\n");
 	if (arg) {
 		ASSERT( pthread_mutex_unlock((pthread_mutex_t *)arg) == 0 );
 		called++;

--- a/contrib/PKI/ca_script/Makefile
+++ b/contrib/PKI/ca_script/Makefile
@@ -1,8 +1,8 @@
 #!/usr/bin/make -s
 #
-# This file is designed to automatize the CA tasks such as:
+# This file is designed to automate the CA tasks such as:
 #  -> init  : create the initial CA tree and the CA root certificate.
-#  -> newcsr: create a new private key and csr. $name and $email must be set. C, ST, L, O, OU may be overwitten (example: make newcsr C=FR)
+#  -> newcsr: create a new private key and csr. $name and $email must be set. C, ST, L, O, OU may be overwritten (example: make newcsr C=FR)
 #  -> cert  : sign a pending CSR and generate the certificate. $name must be provided.
 #  -> revoke: revoke a certificate. $name must be provided.
 #  -> gencrl: update/create the CRL.

--- a/contrib/PKI/ca_script/openssl.cnf
+++ b/contrib/PKI/ca_script/openssl.cnf
@@ -39,7 +39,7 @@ certs		= $dir/certs		# Where the issued certs are kept
 crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
+					# several certificates with same subject.
 new_certs_dir	= $dir/newcerts		# default place for new certs.
 
 certificate	= $dir/public-www/cacert.pem 	# The CA certificate
@@ -50,7 +50,7 @@ crl		= $dir/public-www/crl.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem# The private key
 RANDFILE	= $dir/private/.rand	# private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
@@ -103,7 +103,7 @@ default_bits		= 1024
 default_keyfile 	= privkey.pem
 distinguished_name	= req_distinguished_name
 attributes		= req_attributes
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 
 # Passwords for private keys if not present they will be prompted for
 # input_password = fdsecret

--- a/contrib/PKI/ca_script2/Makefile
+++ b/contrib/PKI/ca_script2/Makefile
@@ -34,7 +34,7 @@ Available commands:\n\
    make newcert name=foo ca=parentca\n\
        Create private key and csr, then issue the certificate (named foo.*)\n\
    make p12 name=foo ca=parentca\n\
-       Same as newcert, but additionnaly creates a pkcs12 file to ship client certificate to Windows or Mac\n\
+       Same as newcert, but additionally creates a pkcs12 file to ship client certificate to Windows or Mac\n\
    make ship name=foo ca=parentca\n\
        Create an archive with the data for the client (useful for freeDiameter peers)\n\
    make revoke name=foo ca=parentca\n\
@@ -132,7 +132,7 @@ newcert:
 		-batch
 	# Hash
 	@ln -sf `cat $(DATA_DIR)/$(ca)/serial.old`.pem $(DATA_DIR)/$(ca)/public/`openssl x509 -noout -hash < $(DATA_DIR)/$(ca)/clients/$(name)/cert.pem`.0
-	# Compiled informations for the client
+	# Compiled information for the client
 	@cat $(DATA_DIR)/$(ca)/clients/$(name)/cert.pem $(DATA_DIR)/$(ca)/public/cachain.pem > $(DATA_DIR)/$(ca)/clients/$(name)/certchain.pem
 	@ln -sf ../../public/crl $(DATA_DIR)/$(ca)/clients/$(name)/crl
 	@ln -sf ../../public/caroot.pem $(DATA_DIR)/$(ca)/clients/$(name)/ca.pem

--- a/contrib/PKI/ca_script2/openssl.cnf
+++ b/contrib/PKI/ca_script2/openssl.cnf
@@ -63,7 +63,7 @@ certs		= $dir/public		# Where the issued certs are kept
 crl_dir		= $dir/public		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
+					# several certificates with same subject.
 new_certs_dir	= $dir/public		# default place for new certs.
 
 certificate	= $dir/public/cacert.pem 	# The CA certificate
@@ -71,7 +71,7 @@ serial		= $dir/serial 		# The current serial number
 crlnumber	= $dir/crlnumber	# the current crl number
 crl		= $dir/public/local.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem	# The private key
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 					# overwrite with -extensions
 name_opt 	= ca_default		# Subject Name options
 cert_opt 	= ca_default		# Certificate field options

--- a/contrib/app_acct_tools/display_self.php
+++ b/contrib/app_acct_tools/display_self.php
@@ -7,7 +7,7 @@
 # See your web server documentation for details.
 # Example for apache2:
 #  (+ detail in http://httpd.apache.org/docs/2.0/ssl/ssl_howto.html#allclients )
-# - in vhost definition file, refence the CA chain of your users certificates:
+# - in vhost definition file, reference the CA chain of your users certificates:
 #  SSLCACertificateFile /var/www/conf/ssl.crt/ca.crt
 # - in vhost file or .htaccess file (adjust Depth to your setup):
 #  <IfModule mod_ssl.c>

--- a/contrib/app_acct_tools/process_records.php
+++ b/contrib/app_acct_tools/process_records.php
@@ -33,7 +33,7 @@ $PROCESSED="processed";
 /**** 3 : Orphan records (optional) ****/
 /* The script can move records belonging to an unterminated session that has not received any new
   record for more than $ORPHAN_DELAY (based on recorded_on field) into an $ORPHANED_TABLE table, so that
-  these records are not re-processed everytime the script runs. 
+  these records are not re-processed every time the script runs. 
   If $ORPHANED_TABLE is empty, this feature is disabled.  */
 $ORPHANED_TABLE="orphans";
 $ORPHAN_DELAY = "2 days";
@@ -148,12 +148,12 @@ if (pg_num_rows($sids) > 0) {
 			$data[/* "sess_duration" */] = $record["Acct-Session-Time"]." seconds";
 		} else {
 			/* No the information is missing, let's compute the approx value with the START record timestamp */
-			$res = pg_query_params($dbconn, 'SELECT t_start."recorded_on" as begining, t_end."recorded_on" - t_start."recorded_on" as duration'.
+			$res = pg_query_params($dbconn, 'SELECT t_start."recorded_on" as beginning, t_end."recorded_on" - t_start."recorded_on" as duration'.
 							' FROM (SELECT "recorded_on" FROM "'.$INCOMING.'"  WHERE "Session-Id" = $1 AND "Acct-Session-Id" = $2 AND "Accounting-Record-Type" = 4 ORDER BY "recorded_on" LIMIT 1) as t_end, '.
 							'      (SELECT "recorded_on" FROM "'.$INCOMING.'"  WHERE "Session-Id" = $1 AND "Acct-Session-Id" = $2 AND "Accounting-Record-Type" = 2 ORDER BY "Accounting-Record-Number", "recorded_on" LIMIT 1) as t_start',
 							array($sid, $asid)) or die('Query failed: ' . pg_last_error() . "\n");
 			$vals = pg_fetch_array($result, null, PGSQL_ASSOC) or die('Internal error, unable to compute session time');
-			$data[/* "sess_start" */] = $vals["begining"];
+			$data[/* "sess_start" */] = $vals["beginning"];
 			$data[/* "sess_duration" */] = $vals["duration"];
 			pg_free_result($res);
 		}

--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -244,7 +244,7 @@ freediameter (1.1.6) RELEASED; urgency=low
 freediameter (1.1.5) RELEASED; urgency=low
 
   * Added compatibility with MAC OS X
-  * Fix behavior of timeout whe nsending messages to allow re-send.
+  * Fix behavior of timeout when sending messages to allow re-send.
   * Several cleanups and new contributions included.
   * Added dependency on C++ compiler for CMakeLists.txt
 

--- a/contrib/debian/freediameter-daemon.init
+++ b/contrib/debian/freediameter-daemon.init
@@ -125,7 +125,7 @@ case "$1" in
         # option to the "reload" entry above. If not, "force-reload" is
         # just the same as "restart" except that it does nothing if the
         # daemon isn't already running.
-        # check wether $DAEMON is running. If so, restart
+        # check whether $DAEMON is running. If so, restart
         start-stop-daemon --stop --test --quiet --pidfile \
             /var/run/$NAME.pid --exec $DAEMON \
             && $0 restart \

--- a/contrib/test_Gx/main_gx.c
+++ b/contrib/test_Gx/main_gx.c
@@ -98,7 +98,7 @@ static int app_gx_entry(char * conffile)
 #endif
 
 
-	// Do registeration and init stuff
+	// Do registration and init stuff
       {
 	struct disp_when data;
        
@@ -526,7 +526,7 @@ int snd_ccr_msg(struct gx_sm_t **sm , struct dict_object *cmd_r )
        
        /* Send the request */
     printf("CCA %p\n",req);
-// Everthing Done Store the state: reply should retreive it 
+// Everything Done Store the state: reply should retrieve it 
        CHECK_FCT_DO( fd_msg_send( &req, NULL, NULL ), goto out );
 
 out:

--- a/contrib/wireshark/sample/README
+++ b/contrib/wireshark/sample/README
@@ -30,7 +30,7 @@ Frames		| Comments
 40-45		| Failed attempt to connect to 192.168.103.30
 		|   where freeDiameter was not started.
 		|
-46-49		| (I think this is trigged by Debug output, 
+46-49		| (I think this is triggered by Debug output, 
 		|   I have to check)
 		|
 50-73		| TLS handshake on first stream pair (#0).

--- a/doc/app_radgw.conf.sample
+++ b/doc/app_radgw.conf.sample
@@ -5,7 +5,7 @@
 # RADIUS/Diameter gateway. Typically, a RADIUS client (e.g. a NAS) will connect to
 # this agent, and the message will be converted to Diameter and sent to a Diameter server.
 #
-# Note that this extension does not provide a fully functionnal RADIUS/Diameter gateway.
+# Note that this extension does not provide a fully functional RADIUS/Diameter gateway.
 # You need to load plugins to handle specific RADIUS messages and convert them to 
 # Diameter apps such as NASREQ, EAP, ... See the next section for information.
 
@@ -54,7 +54,7 @@ RGWX = "extensions/acct.rgwx" : acct;
 # Each RADIUS client must be declared in the form: 
 #   nas = IP / shared-secret ;
 # IP can be ipv4 or ipv6
-# port can be additionaly restricted with brackets: IP[port] (ex: 192.168.0.1[1812])
+# port can be additionally restricted with brackets: IP[port] (ex: 192.168.0.1[1812])
 # shared-secret can be a quoted string, or a list of hexadecimal values.
 # examples:
 # nas = 192.168.100.1 / "secret key" ; # the shared secret buffer is 0x736563726574206b6579 (length 10 bytes)

--- a/doc/dbg_interactive.py.sample
+++ b/doc/dbg_interactive.py.sample
@@ -51,7 +51,7 @@ cvar.fd_debug_one_function = "gc_th_fct"
 
 
 # Print messages to freeDiameter's debug facility
-# Note: the python version does not support printf-like argument list. The formating should be done in python.
+# Note: the python version does not support printf-like argument list. The formatting should be done in python.
 #       See SWIG documentation about varargs functions for more information.
 fd_log(FD_LOG_NOTICE, "3 + 4 = %d" % (7))
 
@@ -70,7 +70,7 @@ fd_ext_dump(0)
 # Display the local Diameter Identity:
 print "Local Diameter Identity:", cvar.fd_g_config.cnf_diamid
 
-# Display realm, using the low-level functions (skip proxy classe definitions):
+# Display realm, using the low-level functions (skip proxy class definitions):
 print "Realm:", _fDpy.fd_config_cnf_diamrlm_get(_fDpy.cvar.fd_g_config)
 
 
@@ -514,9 +514,9 @@ mydwr.add_origin(1) # adds Origin-State-Id in addition.
 # As for sessions, only one dispatch handler can be registered in this extension at the moment.
 # The callback for the handler has the following syntax:
 def dispatch_cb_model(inmsg, inavp, insession):
-   print "Callback trigged on message: "
+   print "Callback triggered on message: "
    inmsg.dump()
-   # inavp is None or the AVP that trigged the callback, depending on how it was registered.
+   # inavp is None or the AVP that triggered the callback, depending on how it was registered.
    if inavp:
      print "From the following AVP:"
      inavp.dump()
@@ -647,7 +647,7 @@ myqueue.length()
 
 ## Variants:
 # All the previous calls are suitable to queue Python objects.
-# In order to interact with objects queued / poped by C counterpart,
+# In order to interact with objects queued / popped by C counterpart,
 # a second parameter must be passed to specify the object type,
 # as follow:
 ev = fd_event()
@@ -721,14 +721,14 @@ p = peer_search("nas.domain.aaa")
 
 # cb2 prototype:
 def my_validate_cb2(pinfo):
-    print "Cb2 callback trigged for peer %s" % (pinfo.pi_diamid)
+    print "Cb2 callback triggered for peer %s" % (pinfo.pi_diamid)
     # Usually, this would be used only to check some TLS properties, 
     # which is not really possible yet through the python interpreter...
     return 0   # return an error code if the peer is not validated
 
 # cb prototype:
 def my_validate_cb(pinfo):
-    print "Validate callback trigged for peer %s" % (pinfo.pi_diamid)
+    print "Validate callback triggered for peer %s" % (pinfo.pi_diamid)
     # If the peer is not allowed to connect:
     #return -1
     # If the peer is authorized:
@@ -737,7 +737,7 @@ def my_validate_cb(pinfo):
     #pinfo.config.pic_flags.sec = PI_SEC_NONE
     # If no decision has been made:
     #return 0
-    # If the peer is temporarily authorized but a second callback must be called after TLS negociation:
+    # If the peer is temporarily authorized but a second callback must be called after TLS negotiation:
     return my_validate_cb2
 
 # Register the callback, it will be called on new incoming connections.

--- a/doc/freediameter.conf.sample
+++ b/doc/freediameter.conf.sample
@@ -34,8 +34,8 @@
 # Default: 5868. Use 0 to disable.
 #SecPort = 5868;
 
-# Use RFC3588 method for TLS protection, where TLS is negociated after CER/CEA exchange is completed
-# on the unsecure connection. The alternative is RFC6733 mechanism, where TLS protects also the
+# Use RFC3588 method for TLS protection, where TLS is negotiated after CER/CEA exchange is completed
+# on the insecure connection. The alternative is RFC6733 mechanism, where TLS protects also the
 # CER/CEA exchange on a dedicated secure port.
 # This parameter only affects outgoing connections.
 # The setting can be also defined per-peer (see Peers configuration section).
@@ -52,7 +52,7 @@
 # This option is ignored if freeDiameter is compiled with DISABLE_SCTP option.
 
 # Prefer TCP instead of SCTP for establishing new connections.
-# This setting may be overwritten per peer in peer configuration blocs.
+# This setting may be overwritten per peer in peer configuration blocks.
 # Default : SCTP is attempted first.
 #Prefer_TCP;
 
@@ -85,7 +85,7 @@
 # How many Diameter peers are allowed to be connecting at the same time ?
 # This parameter limits the number of incoming connections from the time
 # the connection is accepted until the first CER is received.
-# Default: 5 unidentified clients in paralel.
+# Default: 5 unidentified clients in parallel.
 #ThreadsPerServer = 5;
 
 # If this host is used as relay or proxy, it can be useful to limit

--- a/doc/rt_busypeers.conf.sample
+++ b/doc/rt_busypeers.conf.sample
@@ -3,7 +3,7 @@
 #
 # The rt_busypeers extension has two purposes. 
 # - when the local peer receives an error DIAMETER_TOO_BUSY from a peer, 
-#   this extension catchs this error and attempts to retransmit the query to another peer if it makes sense, i.e.:
+#   this extension catches this error and attempts to retransmit the query to another peer if it makes sense, i.e.:
 #      * the peer issuing the error is not the peer referenced in the Destination-Host AVP of the message,
 #      * we have a direct link with the peer that issued the error (see parameter RetryDistantPeers below)
 #

--- a/doc/rt_default.conf.sample
+++ b/doc/rt_default.conf.sample
@@ -65,7 +65,7 @@
 #
 # The TARGET is also of a similar form:
 #    "STR/REG"		-> Will apply the score to this peer if its Diameter-Id is matched by the string or regular expression.
-#    rlm="STR/REG"	-> Idem with the peer's advertized Diameter-Realm.
+#    rlm="STR/REG"	-> Idem with the peer's advertised Diameter-Realm.
 #
 # The SCORE is either numeric (positive or negative), or one of the following constants (see values in libfdcore.h):
 #    NO_DELIVERY

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -114,7 +114,7 @@ FD_EXTENSION_SUBDIR(test_netemul    "Simple Diameter network emulator proxy exte
 
 # The following extension have very little use except for specific tests, so we disable them except in Debug configurations.
 IF (CMAKE_BUILD_TYPE MATCHES "Debug")
-	FD_EXTENSION_SUBDIR(_sample     "Simple extension to demonstrate extension mechanism, for developpers" OFF)
+	FD_EXTENSION_SUBDIR(_sample     "Simple extension to demonstrate extension mechanism, for developers" OFF)
 	FD_EXTENSION_SUBDIR(test_acct   "Receive Accounting-Requests and display the data, but no storage" OFF)
 	FD_EXTENSION_SUBDIR(test_rt_any "Routing extension randomly sending message to any peer available, for testing purpose" OFF)
 ENDIF (CMAKE_BUILD_TYPE MATCHES "Debug")

--- a/extensions/acl_wl/aw_tree.c
+++ b/extensions/acl_wl/aw_tree.c
@@ -230,7 +230,7 @@ int aw_tree_add(char * name, int flags)
 		/* Check if we have a '*' element already that overlapses */
 		ti = (struct tree_item *)(senti->next);
 		if (ti->str == NULL) {
-			fd_log_debug("[acl_wl] Warning: entry '%s' is superseeded by a generic entry at label %d, ignoring.", name, lbl + 1);
+			fd_log_debug("[acl_wl] Warning: entry '%s' is superseded by a generic entry at label %d, ignoring.", name, lbl + 1);
 			return 0;
 		}
 		
@@ -287,7 +287,7 @@ int aw_tree_add(char * name, int flags)
 			/* Check we don't have a '*' entry already */
 			ti = (struct tree_item *)(senti->next);
 			if (ti->str == NULL) {
-				fd_log_debug("[acl_wl] Warning: entry '%s' is superseeded by a generic entry at label 1, ignoring.", name);
+				fd_log_debug("[acl_wl] Warning: entry '%s' is superseded by a generic entry at label 1, ignoring.", name);
 				return 0;
 			}
 			

--- a/extensions/app_diameap/README
+++ b/extensions/app_diameap/README
@@ -9,7 +9,7 @@ Author: Souheil Ben Ayed <souheil@tera.ics.keio.ac.jp>
 ----- SUMMARY -----
 
 DiamEAP is an implementation of the Diameter Extensible Authentication Protocol (EAP) Application (RFC 4072).
-The Diameter protocol is a AAA protocol to securely carry Authentication, Authorization and Accounting informations between the AAA client and the AAA server.
+The Diameter protocol is a AAA protocol to securely carry Authentication, Authorization and Accounting information between the AAA client and the AAA server.
 Diameter EAP Application is a Diameter application that supports authentication using Extensible Authentication Protocol (RFC 3748).  
 
 DiamEAP is designed to be extensible so that any new EAP method can be implemented separately as a shared library called 'EAP method plug-in'.

--- a/extensions/app_radgw/radius.c
+++ b/extensions/app_radgw/radius.c
@@ -555,7 +555,7 @@ int rgw_msg_parse(unsigned char * buf, size_t len, struct rgw_radius_msg_meta **
 	
 	while (pos < end) {
 		if ((size_t) (end - pos) < sizeof(*attr)) {
-			TRACE_DEBUG(INFO, "Trucated attribute found in RADIUS buffer, EINVAL.");
+			TRACE_DEBUG(INFO, "Truncated attribute found in RADIUS buffer, EINVAL.");
 			ret = EINVAL;
 			break;
 		}
@@ -563,7 +563,7 @@ int rgw_msg_parse(unsigned char * buf, size_t len, struct rgw_radius_msg_meta **
 		attr = (struct radius_attr_hdr *) pos;
 	
 		if (pos + attr->length > end || attr->length < sizeof(*attr)) {
-			TRACE_DEBUG(INFO, "Trucated attribute found in RADIUS buffer, EINVAL.");
+			TRACE_DEBUG(INFO, "Truncated attribute found in RADIUS buffer, EINVAL.");
 			ret = EINVAL;
 			break;
 		}

--- a/extensions/app_radgw/rgw_clients.c
+++ b/extensions/app_radgw/rgw_clients.c
@@ -1129,7 +1129,7 @@ int rgw_client_finish_send(struct radius_msg ** msg, struct rgw_radius_msg_meta 
 	return 0;
 }
 
-/* Call this function when a RADIUS request has explicitely no answer (mainly accounting) so 
+/* Call this function when a RADIUS request has explicitly no answer (mainly accounting) so 
 that we purge the duplicate cache and allow further message to be translated again.
 This is useful for example when a temporary error occurred in Diameter (like UNABLE_TO_DELIVER) */
 int rgw_client_finish_nosend(struct rgw_radius_msg_meta * req, struct rgw_client * cli)

--- a/extensions/app_radgw/rgw_common.h
+++ b/extensions/app_radgw/rgw_common.h
@@ -79,7 +79,7 @@ extern struct rgw_api {
 	/* ret >0: critical error (errno), log and exit.
 	   ret 0: continue; 
 	   ret -1: stop processing this message
-	   ret -2: reply the content of rad_ans to the RADIUS client immediatly
+	   ret -2: reply the content of rad_ans to the RADIUS client immediately
 	 */
 	
 	/* handle the corresponding Diameter answer */

--- a/extensions/app_radgw/rgw_plugins.c
+++ b/extensions/app_radgw/rgw_plugins.c
@@ -186,7 +186,7 @@ int rgw_plg_add( char * plgfile, char * conffile, int type, unsigned char ** cod
 	TRACE_DEBUG(FULL, "Loading plugin: %s", plgfile);
 	new->dlo = dlopen(plgfile, RTLD_NOW | RTLD_GLOBAL);
 	if (new->dlo == NULL) {
-		/* An error occured */
+		/* An error occurred */
 		fd_log_error("Loading of app_radgw plugin '%s' failed: %s", plgfile, dlerror());
 		goto error;
 	}
@@ -194,7 +194,7 @@ int rgw_plg_add( char * plgfile, char * conffile, int type, unsigned char ** cod
 	/* Resolve the descriptor */
 	new->descriptor = dlsym( new->dlo, "rgwp_descriptor" );
 	if (new->descriptor == NULL) {
-		/* An error occured */
+		/* An error occurred */
 		fd_log_error("Unable to resolve 'rgwp_descriptor' in app_radgw plugin '%s': %s", plgfile, dlerror());
 		goto error;
 	}
@@ -432,7 +432,7 @@ int rgw_plg_loop_ans(struct rgw_radius_msg_meta *req, struct msg **diam_ans, str
 	
 	/* We might define other return values with special meaning here (ret == -1, ...) for example create a new Diameter request */
 	
-	/* -1: just abord the translation with no more processing. */
+	/* -1: just abort the translation with no more processing. */
 	
 	return 0;
 }

--- a/extensions/app_radgw/rgw_servers.c
+++ b/extensions/app_radgw/rgw_servers.c
@@ -230,7 +230,7 @@ int rgw_servers_start(void)
 	UDPSERV( acct, RGW_PLG_TYPE_ACCT,  );
 	UDPSERV( acct, RGW_PLG_TYPE_ACCT, 6 );
 	
-	TRACE_DEBUG(FULL, "%d UDP servers started succesfully.", idx);
+	TRACE_DEBUG(FULL, "%d UDP servers started successfully.", idx);
 	return 0;
 }
 

--- a/extensions/app_radgw/rgwx_sip.c
+++ b/extensions/app_radgw/rgwx_sip.c
@@ -616,7 +616,7 @@ static int sip_rad_req( struct rgwp_config * cs, struct radius_msg * rad_req, st
 				}
 				else
 				{
-					TRACE_DEBUG(INFO, "Can't extract domain from URI, droping request...");
+					TRACE_DEBUG(INFO, "Can't extract domain from URI, dropping request...");
 					return 1;
 				}	
 				got_Drealm=1;

--- a/extensions/app_sip/TODO
+++ b/extensions/app_sip/TODO
@@ -38,7 +38,7 @@ Diameter-SIP implementation is still under development.
 
 TODO List
 * add in malloc the size of char
-* when getting results from mysql, check lenght
+* when getting results from mysql, check length
 * sort capabilities in LIR/LIA
 * make functions for database access in MAR/MAA
 * order diamsip.h because it's becoming a mess ^^

--- a/extensions/app_sip/app_sip.c
+++ b/extensions/app_sip/app_sip.c
@@ -43,7 +43,7 @@ struct disp_hdl * app_sip_SAR_hdl=NULL;
 struct disp_hdl * app_sip_PPA_hdl=NULL;
 struct disp_hdl * app_sip_RTA_hdl=NULL;
 
-//Suscriber Locator
+//Subscriber Locator
 struct disp_hdl * app_sip_SL_LIR_hdl=NULL;
 
 
@@ -51,7 +51,7 @@ struct disp_hdl * app_sip_SL_LIR_hdl=NULL;
 struct disp_hdl * app_sip_default_hdl=NULL;
 struct session_handler * ds_sess_hdl;
 
-//configuration stucture
+//configuration structure
 struct as_conf * as_conf=NULL;
 static struct as_conf app_sip_conf;
 

--- a/extensions/app_sip/app_sip.h
+++ b/extensions/app_sip/app_sip.h
@@ -147,7 +147,7 @@ int app_sip_LIR_cb( struct msg ** msg, struct avp * avp, struct session * sess, 
 int app_sip_UAR_cb( struct msg ** msg, struct avp * avp, struct session * sess, void * opaque, enum disp_action * act);
 int app_sip_SAR_cb( struct msg ** msg, struct avp * avp, struct session * sess, void * opaque, enum disp_action * act);
 
-//Suscriber Locator
+//Subscriber Locator
 int app_sip_SL_LIR_cb( struct msg ** msg, struct avp * paramavp, struct session * sess, void * opaque, enum disp_action * act);
 //int app_sip_SL_SAR_cb( struct msg ** msg, struct avp * paramavp, struct session * sess, void * opaque, enum disp_action * act);
 

--- a/extensions/app_sip/locationinfosl.c
+++ b/extensions/app_sip/locationinfosl.c
@@ -35,7 +35,7 @@
 *********************************************************************************************************/
 #include "app_sip.h"
 
-//This callback is specific to SUSCRIBER LOCATOR. We must look for the "serving" SIP server
+//This callback is specific to SUBSCRIBER LOCATOR. We must look for the "serving" SIP server
 int app_sip_SL_LIR_cb( struct msg ** msg, struct avp * paramavp, struct session * sess, void * opaque, enum disp_action * act)
 {
 	TRACE_ENTRY("%p %p %p %p", msg, paramavp, sess, act);

--- a/extensions/app_sip/registrationtermination.c
+++ b/extensions/app_sip/registrationtermination.c
@@ -118,7 +118,7 @@ int app_sip_RTR_cb(struct rtrsipaor *structure)
 		got_streason=1;
 	
 	
-	TRACE_DEBUG(FULL,"Request for %d SIP_AOR to be deregistred.",num_aor);
+	TRACE_DEBUG(FULL,"Request for %d SIP_AOR to be deregistered.",num_aor);
 	
 	if((got_username + num_aor)==0)
 	{

--- a/extensions/app_sip/tools/app_sip_ppr.c
+++ b/extensions/app_sip/tools/app_sip_ppr.c
@@ -211,7 +211,7 @@ int main (int argc, char **argv)
 	//TODO: check args
 	if(!connect(sock, (SOCKADDR*)&sin, sizeof(sin)))
     {
-       fprintf(stderr,"Connexion succeed!\n");
+       fprintf(stderr,"Connection succeed!\n");
         
  
         if(send(sock, &pprsip, sizeof(struct pprsipaor), 0))

--- a/extensions/app_sip/tools/app_sip_rtr.c
+++ b/extensions/app_sip/tools/app_sip_rtr.c
@@ -242,7 +242,7 @@ int main (int argc, char **argv)
 	//If no SIP-AOR provided, we remove all
 	if(numaor<1)
 	{
-		fprintf(stderr,"All SIP-AOR of %s will be deregistrated.\n",rtrsip.username);
+		fprintf(stderr,"All SIP-AOR of %s will be deregistered.\n",rtrsip.username);
 	}
 	
 	//We want a username
@@ -277,7 +277,7 @@ int main (int argc, char **argv)
 	//TODO: check args
 	if(!connect(sock, (SOCKADDR*)&sin, sizeof(sin)))
     {
-       fprintf(stderr,"Connexion succeed!\n");
+       fprintf(stderr,"Connection succeed!\n");
         
  
         if(send(sock, &rtrsip, sizeof(struct rtrsipaor), 0))

--- a/extensions/dbg_interactive/helper/xxd.c
+++ b/extensions/dbg_interactive/helper/xxd.c
@@ -37,7 +37,7 @@
  *	    xxdline().
  *  7.06.96 -i printed 'int' instead of 'char'. *blush*
  *	    added Bram's OS2 ifdefs...
- * 18.07.96 gcc -Wall @ SunOS4 is now slient.
+ * 18.07.96 gcc -Wall @ SunOS4 is now silent.
  *	    Added osver for MSDOS/DJGPP/WIN32.
  * 29.08.96 Added size_t to strncmp() for Amiga.
  * 24.03.97 Windows NT support (Phil Hanna). Clean exit for Amiga WB (Bram)

--- a/extensions/dbg_interactive/queues.i
+++ b/extensions/dbg_interactive/queues.i
@@ -68,7 +68,7 @@ struct fifo {
 		return fd_fifo_length ( $self ) ;
 	}
 
-	/* Is the threashold function useful here? TODO... */
+	/* Is the threshold function useful here? TODO... */
 	
 	/* Post an item */
 	void post(PyObject * item, char * type = NULL) {

--- a/extensions/dbg_msg_timings/dbg_msg_timings.c
+++ b/extensions/dbg_msg_timings/dbg_msg_timings.c
@@ -66,7 +66,7 @@ static void mt_hook_cb(enum fd_hook_type type, struct msg * msg, struct peer_hdr
 	CHECK_FCT_DO( fd_msg_hdr(msg, &hdr), return);
 	
 	if (type == HOOK_MESSAGE_RECEIVED) {
-		ASSERT(pmd->received_on.tv_sec); /* otherwise it means the HOOK_DATA_RECEIVED hook was not trigged for this message */
+		ASSERT(pmd->received_on.tv_sec); /* otherwise it means the HOOK_DATA_RECEIVED hook was not triggered for this message */
 		if (hdr->msg_flags & CMD_FLAG_REQUEST) {
 			/* We have received a new request, nothing special to do */
 		} else {
@@ -74,7 +74,7 @@ static void mt_hook_cb(enum fd_hook_type type, struct msg * msg, struct peer_hdr
 			struct fd_hook_permsgdata *qpmd = fd_hook_get_request_pmd(mt_data_hdl, msg);
 			struct timespec delay;
 			ASSERT(qpmd); /* If we do not have it, we must find out why */
-			ASSERT(qpmd->sent_on.tv_sec); /* same, would mean the HOOK_MESSAGE_SENT hook was not trigged */
+			ASSERT(qpmd->sent_on.tv_sec); /* same, would mean the HOOK_MESSAGE_SENT hook was not triggered */
 			TS_DIFFERENCE( &delay, &qpmd->sent_on, &pmd->received_on );
 			CHECK_MALLOC_DO( fd_msg_dump_summary(&buf, &len, NULL, msg, NULL, 0, 1), return );
 			LOG_N("[TIMING] RCV ANS %ld.%06ld sec <-'%s': %s", (long)delay.tv_sec, delay.tv_nsec / 1000, peer ? peer->info.pi_diamid : "<unidentified>", buf);

--- a/extensions/dict_nasreq/dict_nasreq.c
+++ b/extensions/dict_nasreq/dict_nasreq.c
@@ -388,7 +388,7 @@ static int dnr_entry(char * conffile)
 				access, this is the phone number the call came from, using Automatic
 				Number Identification (ANI) or a similar technology.  For use with
 				IEEE 802 access, the Calling-Station-Id AVP MAY contain a MAC
-				address, formated as described in [RAD802.1X].  It SHOULD only be
+				address, formatted as described in [RAD802.1X].  It SHOULD only be
 				present in authentication and/or authorization requests.
 
 				If the Auth-Request-Type AVP is set to authorization-only and the

--- a/extensions/dict_rfc5777/dict_rfc5777.c
+++ b/extensions/dict_rfc5777/dict_rfc5777.c
@@ -1306,7 +1306,7 @@ int dict_rfc5777_init(char * conffile)
 			struct dict_enumval_data 	t_11  = { "MTU Probe                 [RFC1191]*", 	{ .i32 = 11  }};
 			struct dict_enumval_data 	t_12  = { "MTU Reply                 [RFC1191]*", 	{ .i32 = 12  }};
 			struct dict_enumval_data 	t_13  = { "Experimental Flow Control    [Finn]", 	{ .i32 = 13  }};
-			struct dict_enumval_data 	t_14  = { "Expermental Access Control [Estrin]", 	{ .i32 = 14  }};
+			struct dict_enumval_data 	t_14  = { "Experimental Access Control [Estrin]", 	{ .i32 = 14  }};
 			struct dict_enumval_data 	t_15  = { "???                      [VerSteeg]", 	{ .i32 = 15  }};
 			struct dict_enumval_data 	t_16  = { "IMI Traffic Descriptor        [Lee]", 	{ .i32 = 16  }};
 			struct dict_enumval_data 	t_17  = { "Extended Internet Protocol[RFC1385]", 	{ .i32 = 17  }};

--- a/extensions/rt_default/rtd_conf.y
+++ b/extensions/rt_default/rtd_conf.y
@@ -141,7 +141,7 @@ void yyerror (YYLTYPE *ploc, char * conffile, char const *s)
 /* An integer value */
 %token <integer> INTEGER
 
-/* The types for this gramar */
+/* The types for this grammar */
 %type <tstring>  TSTRING
 %type <criteria> CRITERIA
 %type <target> 	 TARGET

--- a/extensions/rt_ereg/rtereg.c
+++ b/extensions/rt_ereg/rtereg.c
@@ -324,7 +324,7 @@ static int rtereg_init_config(void)
 {
 	/* Initialize the configuration */
 	if ((rtereg_conf=calloc(sizeof(*rtereg_conf), 1)) == NULL) {
-		LOG_E("[rt_ereg] malloc failured");
+		LOG_E("[rt_ereg] malloc failed");
 		return 1;
 	}
 	rtereg_conf_size = 1;

--- a/extensions/rt_redirect/redir_expiry.c
+++ b/extensions/rt_redirect/redir_expiry.c
@@ -59,7 +59,7 @@ void * redir_exp_thr_fct(void * arg)
 again:
 		/* Check if there are expiring entries available */
 		if (FD_IS_LIST_EMPTY(&expire_list)) {
-			/* Just wait for a change or cancelation */
+			/* Just wait for a change or cancellation */
 			CHECK_POSIX_DO( pthread_cond_wait( &exp_cnd, &redir_exp_peer_lock ), break /* this might not pop the cleanup handler, but since we ASSERT(0), it is not the big issue... */ );
 			/* Restart the loop on wakeup */
 			goto again;

--- a/extensions/rt_redirect/redir_out.c
+++ b/extensions/rt_redirect/redir_out.c
@@ -198,7 +198,7 @@ static int apply_rule(struct redir_entry * e, struct msg * msg, struct fd_list *
 		/* the candidates list is not guaranteed to be ordered at this time, so we cannot avoid the two imbricated loops */
 		struct rtd_candidate * cand = (struct rtd_candidate *) lic;
 
-		/* Is this candidate in the "Redirect-Host" list ? We must search caseinsentive here. */
+		/* Is this candidate in the "Redirect-Host" list ? We must search case-insensitive here. */
 		for (lirh = e->target_peers_list.next; lirh != &e->target_peers_list; lirh = lirh->next) {
 			struct redir_host * host = lirh->o;
 			int cont;

--- a/extensions/test_app/ta_bench.c
+++ b/extensions/test_app/ta_bench.c
@@ -262,7 +262,7 @@ static void ta_bench_start() {
 	
 	/* Now loop until timeout is reached */
 	do {
-		/* Do not create more that NB_CONCURRENT_MESSAGES in paralel */
+		/* Do not create more that NB_CONCURRENT_MESSAGES in parallel */
 		int ret = my_sem_timedwait(&ta_sem, &end_time);
 		if (ret == -1) {
 			ret = errno;

--- a/extensions/test_app/ta_conf.l
+++ b/extensions/test_app/ta_conf.l
@@ -35,7 +35,7 @@
 
 /* Lex extension's configuration parser.
  *
- * The configuration file contains a default priority, and a list of peers with optional overwite priority.
+ * The configuration file contains a default priority, and a list of peers with optional overwrite priority.
  * -- see the app_test.conf.sample file for more detail.
  */
 

--- a/extensions/test_sip/test_sip.c
+++ b/extensions/test_sip/test_sip.c
@@ -54,7 +54,7 @@ struct disp_hdl * test_sip_RTR_hdl=NULL;
 
 struct disp_hdl * test_sip_default_hdl=NULL;
 
-//configuration stucture
+//configuration structure
 struct ts_conf * ts_conf=NULL;
 static struct ts_conf test_sip_conf;
 

--- a/include/freeDiameter/CMakeLists.txt
+++ b/include/freeDiameter/CMakeLists.txt
@@ -38,7 +38,7 @@ OPTION(DISABLE_PEER_EXPIRY "Disable RFC3539 Peers Connections Expiration after i
 
 # The following workaround increases compatibility with some implementations without breaking anything in freeDiameter,
 # so it can be enabled without risk. We keep it disabled by default anyway for those people who use freeDiameter to check the
-# compliancy of their implementation with the Diameter RFC...
+# compliance of their implementation with the Diameter RFC...
 OPTION(WORKAROUND_ACCEPT_INVALID_VSAI "Do not reject a CER/CEA with a Vendor-Specific-Application-Id AVP containing both Auth- and Acct- application AVPs?" OFF)
 
 MARK_AS_ADVANCED(DISABLE_SCTP DEBUG_SCTP SCTP_USE_MAPPED_ADDRESSES ERRORS_ON_TODO DEBUG_WITH_META DIAMID_IDNA_IGNORE DIAMID_IDNA_REJECT DISABLE_PEER_EXPIRY WORKAROUND_ACCEPT_INVALID_VSAI)

--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -187,7 +187,7 @@ struct fd_config {
 	struct dictionary *cnf_dict;	/* pointer to the global dictionary */
 	struct fifo	  *cnf_main_ev;	/* events for the daemon's main (struct fd_event items) */
 };
-extern struct fd_config *fd_g_config; /* The pointer to access the global configuration, initalized in main */
+extern struct fd_config *fd_g_config; /* The pointer to access the global configuration, initialized in main */
 
 
 
@@ -199,7 +199,7 @@ extern struct fd_config *fd_g_config; /* The pointer to access the global config
 enum peer_state {
 	/* Stable states */
 	STATE_NEW = 0,		/* The peer has been just been created, PSM thread not started yet */
-	STATE_OPEN,		/* Connexion established */
+	STATE_OPEN,		/* Connection established */
 	
 	/* Peer state machine */
 	STATE_CLOSED,		/* No connection established, will re-attempt after TcTimer. */
@@ -270,7 +270,7 @@ extern const char *peer_state_str[];
 #define PI_EXP_INACTIVE	1	/* the peer entry expires (i.e. is deleted) after pi_lft seconds without activity */
 
 #define PI_PRST_NONE	0	/* the peer entry is deleted after disconnection / error */
-#define PI_PRST_ALWAYS	1	/* the peer entry is persistant (will be kept as ZOMBIE in case of error) */
+#define PI_PRST_ALWAYS	1	/* the peer entry is persistent (will be kept as ZOMBIE in case of error) */
 			
 /* Information about a remote peer */
 struct peer_info {
@@ -313,7 +313,7 @@ struct peer_info {
 		uint32_t	pir_orstate;	/* Origin-State-Id value */
 		os0_t		pir_prodname;	/* copy of Product-Name AVP (\0 terminated) */
 		uint32_t	pir_firmrev;	/* Content of the Firmware-Revision AVP */
-		int		pir_relay;	/* The remote peer advertized the relay application */
+		int		pir_relay;	/* The remote peer advertised the relay application */
 		struct fd_list	pir_apps;	/* applications advertised by the remote peer, except relay (pi_flags.relay) */
 		int		pir_isi;	/* Inband-Security-Id advertised (PI_SEC_* bits) */
 		
@@ -327,7 +327,7 @@ struct peer_info {
 		
 	} runtime;	/* Data populated after connection, may change between 2 connections -- not used by fd_peer_add */
 	
-	struct fd_list	pi_endpoints;	/* Endpoint(s) of the remote peer (configured, discovered, or advertized). list of struct fd_endpoint. DNS resolved if empty. */
+	struct fd_list	pi_endpoints;	/* Endpoint(s) of the remote peer (configured, discovered, or advertised). list of struct fd_endpoint. DNS resolved if empty. */
 };
 
 
@@ -354,7 +354,7 @@ extern pthread_rwlock_t fd_g_peers_rw; /* protect the list */
  *  cb_data	: opaque data to pass to the callback.
  *
  * DESCRIPTION: 
- *  Add a peer to the list of peers to which the daemon must maintain a connexion.
+ *  Add a peer to the list of peers to which the daemon must maintain a connection.
  *
  *  The content of info parameter is copied, except for the list of endpoints if 
  * not empty, which is simply moved into the created object. It means that the list
@@ -632,7 +632,7 @@ int fd_msg_parse_or_error( struct msg ** msg, struct msg **error );
  *  acct	: Support acct app part.
  *
  * DESCRIPTION: 
- *   Registers an application to be advertized in CER/CEA exchanges.
+ *   Registers an application to be advertised in CER/CEA exchanges.
  *  Messages with an application-id matching a registered value are passed to the dispatch module,
  * while other messages are simply relayed or an error is returned (if local node does not relay)
  *
@@ -898,7 +898,7 @@ struct fd_endpoint {
 	
 #define	EP_FL_CONF	(1 << 0)	/* This endpoint is statically configured in a configuration file */
 #define	EP_FL_DISC	(1 << 1)	/* This endpoint was resolved from the Diameter Identity or other DNS query */
-#define	EP_FL_ADV	(1 << 2)	/* This endpoint was advertized in Diameter CER/CEA exchange */
+#define	EP_FL_ADV	(1 << 2)	/* This endpoint was advertised in Diameter CER/CEA exchange */
 #define	EP_FL_LL	(1 << 3)	/* Lower layer mechanism provided this endpoint */
 #define	EP_FL_PRIMARY	(1 << 4)	/* This endpoint is primary in a multihomed SCTP association */
 #define	EP_ACCEPTALL	(1 << 15)	/* This flag allows bypassing the address filter in fd_ep_add_merge. */
@@ -1052,7 +1052,7 @@ enum fd_hook_type {
 	HOOK_MESSAGE_ROUTING_FORWARD,
 		/* Hook called when a received message is deemed to be not handled locally by the routing_dispatch process.
 		   The decision of knowing which peer it will be sent to is not made yet (or if an error will be returned).
-		   The hook is trigged before the callbacks registered with fd_rt_fwd_register are called.
+		   The hook is triggered before the callbacks registered with fd_rt_fwd_register are called.
 		 - {msg} points to the message. Again, the objects may not have been dictionary resolved. 
 		    If you try to call fd_msg_parse_dict, it will slow down the operation of a relay agent.
 		 - {peer} is NULL.
@@ -1062,7 +1062,7 @@ enum fd_hook_type {
 	
 	HOOK_MESSAGE_ROUTING_LOCAL,
 		/* Hook called when a received message is handled locally by the routing_dispatch process (i.e., not forwarded).
-		   The hook is trigged before the callbacks registered with fd_disp_register are called.
+		   The hook is triggered before the callbacks registered with fd_disp_register are called.
 		 - {msg} points to the message. Here, the message has been already parsed completely & successfully.
 		 - {peer} is NULL.
 		 - {other} is NULL.
@@ -1227,7 +1227,7 @@ enum fd_stat_type {
  *  total_count	  : (out) Total number of items that this queue has processed (always growing, use deltas for monitoring)
  *  total	  : (out) Cumulated time all items spent in this queue, including blocking time (always growing, use deltas for monitoring)
  *  blocking      : (out) Cumulated time threads trying to post new items were blocked (queue full).
- *  last          : (out) For the last element retrieved from the queue, how long it took between posting (including blocking) and poping
+ *  last          : (out) For the last element retrieved from the queue, how long it took between posting (including blocking) and popping
  *  
  * DESCRIPTION: 
  *   Get statistics information about a given queue. 

--- a/include/freeDiameter/libfdproto.h
+++ b/include/freeDiameter/libfdproto.h
@@ -379,7 +379,7 @@ static char * file_bname_init(char * full) { file_bname = basename(full); return
 #define TRACE_ENTRY(_format,_args... ) \
 		LOG_A("[enter] %s(" _format ") {" #_args "}", __PRETTY_FUNCTION__, ##_args );
 
-/* Helper for debugging by adding traces -- for debuging a specific location of the code */
+/* Helper for debugging by adding traces -- for debugging a specific location of the code */
 #define TRACE_HERE()	\
 		LOG_F(" -- debug checkpoint %d -- ", fd_breakhere());
 int fd_breakhere(void);
@@ -707,7 +707,7 @@ void fd_sa_sdump_numeric(char * buf /* must be at least sSA_DUMP_STRLEN */, sSA 
 #   define ntohll(x) (x)
 #   define htonll(x) (x)
 # else /* HOST_BIG_ENDIAN */
-    /* For these systems, we must reverse the bytes. Use ntohl and htonl on sub-32 blocs, and inverse these blocs. */
+    /* For these systems, we must reverse the bytes. Use ntohl and htonl on sub-32 blocks, and inverse these blocks. */
 #   define ntohll(x) (typeof (x))( (((uint64_t)ntohl( (uint32_t)(x))) << 32 ) | ((uint64_t) ntohl( ((uint64_t)(x)) >> 32 )))
 #   define htonll(x) (typeof (x))( (((uint64_t)htonl( (uint32_t)(x))) << 32 ) | ((uint64_t) htonl( ((uint64_t)(x)) >> 32 )))
 # endif /* HOST_BIG_ENDIAN */
@@ -790,7 +790,7 @@ typedef char * DiamId_t;
 #endif /* HOST_NAME_MAX */
 
 /* Check if a binary string contains a valid Diameter Identity value.
-  rfc3588 states explicitely that such a Diameter Identity consists only of ASCII characters. */
+  rfc3588 states explicitly that such a Diameter Identity consists only of ASCII characters. */
 int fd_os_is_valid_DiameterIdentity(uint8_t * os, size_t ossz);
 
 /* The following function validates a string as a Diameter Identity or applies the IDNA transformation on it
@@ -801,7 +801,7 @@ int fd_os_validate_DiameterIdentity(char ** id, size_t * inoutsz, int memory);
 
 /* Create an order relationship for binary strings (not needed to be \0 terminated).
    It does NOT mimic strings relationships so that it is more efficient. It is case sensitive.
-   (the strings are actually first ordered by their lengh, then by their bytes contents)
+   (the strings are actually first ordered by their length, then by their bytes contents)
    returns: -1 if os1 < os2;  +1 if os1 > os2;  0 if they are equal */
 int fd_os_cmp_int(os0_t os1, size_t os1sz, os0_t os2, size_t os2sz);
 #define fd_os_cmp(_o1, _l1, _o2, _l2)  fd_os_cmp_int((os0_t)(_o1), _l1, (os0_t)(_o2), _l2)
@@ -868,7 +868,7 @@ static __inline__ int fd_thr_term(pthread_t * th)
 
 
 /*************
- Cancelation cleanup handlers for common objects
+ Cancellation cleanup handlers for common objects
  *************/
 static __inline__ void fd_cleanup_mutex( void * mutex )
 {
@@ -1236,7 +1236,7 @@ enum dict_avp_basetype {
  *   interpreted : The result of interpretation is stored here. The format and meaning depends on each type.
  *
  * DESCRIPTION:
- *   This callback can be provided with a derived type in order to facilitate the interpretation of formated data.
+ *   This callback can be provided with a derived type in order to facilitate the interpretation of formatted data.
  *  For example, when an AVP of type "Address" is received, it can be used to convert the octetstring into a struct sockaddr.
  *  This callback is not called directly, but through the message's API msg_avp_value_interpret function.
  *
@@ -1249,11 +1249,11 @@ typedef int (*dict_avpdata_interpret) (union avp_value * value, void * interpret
  * CALLBACK:	dict_avpdata_encode
  *
  * PARAMETERS:
- *   data	: The formated data that must be stored in the AVP value.
+ *   data	: The formatted data that must be stored in the AVP value.
  *   val	: Pointer to the AVP value storage area where the data must be stored.
  *
  * DESCRIPTION:
- *   This callback can be provided with a derived type in order to facilitate the encoding of formated data.
+ *   This callback can be provided with a derived type in order to facilitate the encoding of formatted data.
  *  For example, it can be used to convert a struct sockaddr in an AVP value of type Address.
  *  This callback is not called directly, but through the message's API msg_avp_value_encode function.
  *  If the callback is defined for an OctetString based type, the created string must be malloc'd. free will be called
@@ -1278,7 +1278,7 @@ typedef int (*dict_avpdata_encode) (void * data, union avp_value * val);
  *  fd_msg_parse_dict function. When this callback is present, the value of the AVP that has
  * been parsed is passed to this function for finer granularity check. For example for some
  * speccific AVP, the format of an OCTETSTRING value can be further checked, or the
- * interger value can be verified.
+ * integer value can be verified.
  *
  * RETURN VALUE:
  *  0      	: The value is valid.
@@ -1664,7 +1664,7 @@ The application associated to a command is retrieved with APPLICATION_OF_COMMAND
 
 To create the rules for children of commands, see the DICT_RULE related part.
 
-Note that the "Request" and "Answer" commands are two independant objects. This allows to have different rules for each.
+Note that the "Request" and "Answer" commands are two independent objects. This allows to have different rules for each.
 
 - fd_dict_new:
  Sample code for command creation:
@@ -1727,7 +1727,7 @@ Note that the "Request" and "Answer" commands are two independant objects. This 
 enum rule_position {
 	RULE_FIXED_HEAD = 1,	/* The AVP must be at the head of the group. The rule_order field is used to specify the position. */
 	RULE_REQUIRED,		/* The AVP must be present in the parent, but its position is not defined. */
-	RULE_OPTIONAL,		/* The AVP may be present in the message. Used to specify a max number of occurences for example */
+	RULE_OPTIONAL,		/* The AVP may be present in the message. Used to specify a max number of occurrences for example */
 	RULE_FIXED_TAIL		/* The AVP must be at the end of the group. The rule_order field is used to specify the position. */
 };
 
@@ -1736,8 +1736,8 @@ struct dict_rule_data {
 	struct dict_object	*rule_avp;	/* Pointer to the AVP object that is concerned by this rule */
 	enum rule_position	 rule_position;	/* The position in which the rule_avp must appear in the parent */
 	unsigned		 rule_order;	/* for RULE_FIXED_* rules, the place. 1,2,3.. for HEAD rules; ...,3,2,1 for TAIL rules. */
-	int	 		 rule_min;	/* Minimum number of occurences. -1 means "default": 0 for optional rules, 1 for other rules */
-	int			 rule_max;	/* Maximum number of occurences. -1 means no maximum. 0 means the AVP is forbidden. */
+	int	 		 rule_min;	/* Minimum number of occurrences. -1 means "default": 0 for optional rules, 1 for other rules */
+	int			 rule_max;	/* Maximum number of occurrences. -1 means no maximum. 0 means the AVP is forbidden. */
 };
 
 /* The criteria for searching a rule in the dictionary */
@@ -2909,7 +2909,7 @@ struct disp_when {
  *  All fields have the same constraints and meaning as in DISP_REG_AVP. In addition, the "value" field must be set
  *  and points to a valid DICT_ENUMVAL object.
  *
- * Here is a sumary of the fields: ( M : must be set; m : may be set; 0 : ignored )
+ * Here is a summary of the fields: ( M : must be set; m : may be set; 0 : ignored )
  *  field:     app_id    command     avp    value
  * APPID :       M          0         0       0
  * CC    :       m          M         0       0
@@ -2935,7 +2935,7 @@ enum disp_action {
  *  action	: upon return, this tells the daemon what to do next.
  *
  * DESCRIPTION:
- *   Called when a received message matchs the condition for which the callback was registered.
+ *   Called when a received message matches the condition for which the callback was registered.
  * This callback may do any kind of processing on the message, including:
  *  - create an answer for a request.
  *  - proxy a request or message, add / remove the Proxy-Info AVP, then forward the message.
@@ -3103,13 +3103,13 @@ int fd_fifo_move ( struct fifo * oldq, struct fifo * newq, struct fifo ** loc_up
  *
  * PARAMETERS:
  *  queue	  : The queue from which to retrieve the information.
- *  current_count : How many items in the queue at the time of execution. This changes each time an item is pushed or poped.
+ *  current_count : How many items in the queue at the time of execution. This changes each time an item is pushed or popped.
  *  limit_count   : The maximum number of items allowed in this queue. This is specified during queue creation.
  *  highest_count : The maximum number of items this queue has contained. This enables to see if limit_count count was reached.
  *  total_count   : the total number of items that went through the queue (already pop'd). Always increasing.
  *  total	  : Cumulated time all items spent in this queue, including blocking time (always growing, use deltas for monitoring)
  *  blocking      : Cumulated time threads trying to post new items were blocked (queue full).
- *  last          : For the last element retrieved from the queue, how long it take between posting (including blocking) and poping
+ *  last          : For the last element retrieved from the queue, how long it take between posting (including blocking) and popping
  *
  * DESCRIPTION:
  *  Retrieve the timing information associated with a queue, for monitoring purpose.
@@ -3142,7 +3142,7 @@ int fd_fifo_length ( struct fifo * queue );
  *  queue	: The queue for which the thresholds are being set.
  *  data	: An opaque pointer that is passed to h_cb and l_cb callbacks.
  *  high        : The high-level threshold. If the number of elements in the queue increase to this value, h_cb is called.
- *  h_cb        : if not NULL, a callback to call when the queue lengh is bigger than "high".
+ *  h_cb        : if not NULL, a callback to call when the queue length is bigger than "high".
  *  low         : The low-level threshold. Must be < high.
  *  l_cb        : If the number of elements decrease to low, this callback is called.
  *
@@ -3260,7 +3260,7 @@ int fd_fifo_timedget_int ( struct fifo * queue, void ** item, const struct times
  *
  * PARAMETERS:
  *  queue	: The queue to test.
- *  abstime	: the absolute time until which we can block waiting for an item. If NULL, the function returns immediatly.
+ *  abstime	: the absolute time until which we can block waiting for an item. If NULL, the function returns immediately.
  *
  * DESCRIPTION:
  *  This function is similar to select(), it waits for data to be available in the queue

--- a/libfdcore/cnxctx.c
+++ b/libfdcore/cnxctx.c
@@ -303,7 +303,7 @@ struct cnxctx * fd_cnx_cli_connect_tcp(sSA * sa /* contains the port already */,
 		}
 	}
 
-	/* Once the socket is created successfuly, prepare the remaining of the cnx */
+	/* Once the socket is created successfully, prepare the remaining of the cnx */
 	CHECK_MALLOC_DO( cnx = fd_cnx_init(1), { shutdown(sock, SHUT_RDWR); close(sock); return NULL; } );
 
 	cnx->cc_socket = sock;
@@ -377,7 +377,7 @@ struct cnxctx * fd_cnx_cli_connect_sctp(int no_ip6, uint16_t port, struct fd_lis
 		}
 	}
 
-	/* Once the socket is created successfuly, prepare the remaining of the cnx */
+	/* Once the socket is created successfully, prepare the remaining of the cnx */
 	CHECK_MALLOC_DO( cnx = fd_cnx_init(1), { shutdown(sock, SHUT_RDWR); close(sock); return NULL; } );
 
 	cnx->cc_socket = sock;
@@ -830,7 +830,7 @@ static void * rcvthr_notls_tcp(void * arg)
 
 		rcv_data.length = ((size_t)header[1] << 16) + ((size_t)header[2] << 8) + (size_t)header[3];
 
-		/* Check the received word is a valid begining of a Diameter message */
+		/* Check the received word is a valid beginning of a Diameter message */
 		if ((header[0] != DIAMETER_VERSION)	/* defined in <libfdproto.h> */
 		   || (rcv_data.length > DIAMETER_MSG_SIZE_MAX)) { /* to avoid too big mallocs */
 			/* The message is suspect */
@@ -844,7 +844,7 @@ static void * rcvthr_notls_tcp(void * arg)
 		memcpy(rcv_data.buffer, header, sizeof(header));
 
 		while (received < rcv_data.length) {
-			pthread_cleanup_push(free_rcvdata, &rcv_data); /* In case we are canceled, clean the partialy built buffer */
+			pthread_cleanup_push(free_rcvdata, &rcv_data); /* In case we are canceled, clean the partially built buffer */
 			ret = fd_cnx_s_recv(conn, rcv_data.buffer + received, rcv_data.length - received);
 			pthread_cleanup_pop(0);
 
@@ -930,7 +930,7 @@ fatal:
 }
 #endif /* DISABLE_SCTP */
 
-/* Start receving messages in clear (no TLS) on the connection */
+/* Start receiving messages in clear (no TLS) on the connection */
 int fd_cnx_start_clear(struct cnxctx * conn, int loop)
 {
 	TRACE_ENTRY("%p %i", conn, loop);
@@ -989,7 +989,7 @@ again:
 				case GNUTLS_E_INTERRUPTED:
 					if (!fd_cnx_teststate(conn, CC_STATUS_CLOSING))
 						goto again;
-					TRACE_DEBUG(FULL, "Connection is closing, so abord gnutls_record_recv now.");
+					TRACE_DEBUG(FULL, "Connection is closing, so abort gnutls_record_recv now.");
 					break;
 
 				case GNUTLS_E_UNEXPECTED_PACKET_LENGTH:
@@ -1063,7 +1063,7 @@ end:
 }
 
 
-/* The function that receives TLS data and re-builds a Diameter message -- it exits only on error or cancelation */
+/* The function that receives TLS data and re-builds a Diameter message -- it exits only on error or cancellation */
 /* 	   For the case of DTLS, since we are not using SCTP_UNORDERED, the messages over a single stream are ordered.
 	   Furthermore, as long as messages are shorter than the MTU [2^14 = 16384 bytes], they are delivered in a single
 	   record, as far as I understand.
@@ -1106,7 +1106,7 @@ int fd_tls_rcvthr_core(struct cnxctx * conn, gnutls_session_t session)
 		memcpy(rcv_data.buffer, header, sizeof(header));
 
 		while (received < rcv_data.length) {
-			pthread_cleanup_push(free_rcvdata, &rcv_data); /* In case we are canceled, clean the partialy built buffer */
+			pthread_cleanup_push(free_rcvdata, &rcv_data); /* In case we are canceled, clean the partially built buffer */
 			ret = fd_tls_recv_handle_error(conn, session, rcv_data.buffer + received, rcv_data.length - received);
 			pthread_cleanup_pop(0);
 
@@ -1996,7 +1996,7 @@ void fd_cnx_destroy(struct cnxctx * conn)
 				/* Now wait for all decipher threads to terminate */
 				fd_sctp3436_waitthreadsterm(conn);
 			} else {
-				/* Abord the threads, the connection is dead already */
+				/* Abort the threads, the connection is dead already */
 				fd_sctp3436_stopthreads(conn);
 			}
 

--- a/libfdcore/dict_base_proto.c
+++ b/libfdcore/dict_base_proto.c
@@ -1560,7 +1560,7 @@ int fd_dict_base_protocol(struct dictionary * dict)
 				the Failed-AVP MAY contain the grouped AVP which in turn contains the
 				single offending AVP.  The same method MAY be employed if the grouped
 				AVP itself is embedded in yet another grouped AVP and so on.  In this
-				case, the Failed-AVP MAY contain the grouped AVP heirarchy up to the
+				case, the Failed-AVP MAY contain the grouped AVP hierarchy up to the
 				single offending AVP.  This enables the recipient to detect the
 				location of the offending AVP when embedded in a group.
 

--- a/libfdcore/events.c
+++ b/libfdcore/events.c
@@ -115,7 +115,7 @@ const char * fd_ev_str(int event)
 }
 
 /**********************************************************************/
-/* Trigged events */
+/* Triggered events */
 /* This allows extensions to register for / send triggers to other extensions */
 /* It is used for example for users interactions (through signals or ...) */
 

--- a/libfdcore/extensions.c
+++ b/libfdcore/extensions.c
@@ -160,10 +160,10 @@ int fd_ext_load()
 		LOG_D( "Loading : %s", ext->filename);
 		
 		/* Load the extension */
-		/* We resolve symbols immediatly so it's easier to find problems in ABI */
+		/* We resolve symbols immediately so it's easier to find problems in ABI */
 		ext->handler = dlopen(ext->filename, RTLD_NOW | RTLD_GLOBAL);
 		if (ext->handler == NULL) {
-			/* An error occured; try loading with lazy resolution for more diagnostics */
+			/* An error occurred; try loading with lazy resolution for more diagnostics */
 			LOG_F("Loading of extension %s failed: %s", ext->filename, dlerror());
 			ext->handler = dlopen(ext->filename, RTLD_LAZY | RTLD_GLOBAL);
 			if (ext->handler) {
@@ -181,7 +181,7 @@ int fd_ext_load()
 		fd_ext_init = ( int (*) (int, int, char *) )dlsym( ext->handler, "fd_ext_init" );
 		
 		if (fd_ext_init == NULL) {
-			/* An error occured */
+			/* An error occurred */
 			TRACE_ERROR("Unable to resolve symbol 'fd_ext_init' for extension %s: %s", ext->filename, dlerror());
 			return EINVAL;
 		}

--- a/libfdcore/fdcore-internal.h
+++ b/libfdcore/fdcore-internal.h
@@ -112,7 +112,7 @@ int fd_queues_init(void);
 int fd_queues_init_after_conf(void);
 int fd_queues_fini(struct fifo ** queue);
 
-/* Trigged events */
+/* Triggered events */
 int fd_event_trig_call_cb(int trigger_val);
 int fd_event_trig_fini(void);
 

--- a/libfdcore/fdd.l
+++ b/libfdcore/fdd.l
@@ -36,7 +36,7 @@
 /* Lex configuration parser.
  *
  * This file defines the token for parsing the daemon's configuration file
- * Note that each extension has a separate independant configuration file.
+ * Note that each extension has a separate independent configuration file.
  *
  * Note : This module is NOT thread-safe. All processing must be done from one thread only.
  */

--- a/libfdcore/fdd.y
+++ b/libfdcore/fdd.y
@@ -36,7 +36,7 @@
 /* Yacc configuration parser.
  *
  * This file defines the grammar of the configuration file.
- * Note that each extension has a separate independant configuration file.
+ * Note that each extension has a separate independent configuration file.
  *
  * Note : This module is NOT thread-safe. All processing must be done from one thread only.
  */
@@ -53,7 +53,7 @@
 
 %{
 #include "fdcore-internal.h"
-#include "fdd.tab.h"	/* bug : bison does not define the YYLTYPE before including this bloc, so... */
+#include "fdd.tab.h"	/* bug : bison does not define the YYLTYPE before including this block, so... */
 
 /* The Lex parser prototype */
 int fddlex(YYSTYPE *lvalp, YYLTYPE *llocp);
@@ -136,7 +136,7 @@ struct peer_info fddpi;
 /* -------------------------------------- */
 %%
 
-	/* The grammar definition - Sections blocs. */
+	/* The grammar definition - Sections blocks. */
 conffile:		/* Empty is OK -- for simplicity here, we reject in daemon later */
 			| conffile identity
 			| conffile realm

--- a/libfdcore/messages.c
+++ b/libfdcore/messages.c
@@ -494,7 +494,7 @@ int fd_msg_parse_or_error( struct msg ** msg, struct msg **error)
 			if (rc) {
 				switch (rc->u32 / 1000) {
 					case 1:	/* 1xxx : Informational */
-					case 2:	/* 2xxx : Sucess */
+					case 2:	/* 2xxx : Success */
 						/* In these cases, we want the message to validate the ABNF, so we will discard the bad message */
 						break;
 

--- a/libfdcore/p_ce.c
+++ b/libfdcore/p_ce.c
@@ -265,7 +265,7 @@ static int save_remote_CE_info(struct msg * msg, struct fd_peer * peer, struct f
 	
 	CHECK_FCT( fd_msg_browse( msg, MSG_BRW_FIRST_CHILD, &avp, NULL) );
 	
-	/* Loop on all AVPs and save what we are interrested into */
+	/* Loop on all AVPs and save what we are interested into */
 	while (avp) {
 		struct avp_hdr * hdr;
 
@@ -369,7 +369,7 @@ static int save_remote_CE_info(struct msg * msg, struct fd_peer * peer, struct f
 							return EINVAL;
 						} );
 
-					/* Save this endpoint in the list as advertized */
+					/* Save this endpoint in the list as advertised */
 					CHECK_FCT( fd_ep_add_merge( &peer->p_hdr.info.pi_endpoints, (sSA *)&ss, sizeof(sSS), EP_FL_ADV ) );
 				}
 				break;

--- a/libfdcore/p_expiry.c
+++ b/libfdcore/p_expiry.c
@@ -105,7 +105,7 @@ static void * exp_th_fct(void * arg)
 		
 		/* Check if there are expiring peers available */
 		if (FD_IS_LIST_EMPTY(&exp_list)) {
-			/* Just wait for a change or cancelation */
+			/* Just wait for a change or cancellation */
 			CHECK_POSIX_DO( pthread_cond_wait( &exp_cnd, &exp_mtx ), { ASSERT(0); } );
 			/* Restart the loop on wakeup */
 			continue;

--- a/libfdcore/p_out.c
+++ b/libfdcore/p_out.c
@@ -112,7 +112,7 @@ static void * out_thr(void * arg)
 		fd_log_threadname ( buf );
 	}
 	
-	/* Loop until cancelation */
+	/* Loop until cancellation */
 	while (!stop) {
 		int ret;
 		

--- a/libfdcore/p_sr.c
+++ b/libfdcore/p_sr.c
@@ -127,7 +127,7 @@ loop:
 
 		/* Check if there are expiring requests available */
 		if (FD_IS_LIST_EMPTY(&srlist->exp)) {
-			/* Just wait for a change or cancelation */
+			/* Just wait for a change or cancellation */
 			CHECK_POSIX_DO( pthread_cond_wait( &srlist->cnd, &srlist->mtx ), goto unlock );
 			/* Restart the loop on wakeup */
 			goto loop;
@@ -357,7 +357,7 @@ void fd_p_sr_on_disconnect(struct sr_list * srlist)
 	while (l->next != &srlist->srs) {
 		struct sentreq * n = (struct sentreq *)(l->next);
 		if (fd_msg_is_routable(n->req)) {
-			// avance
+			// advance
 			l = (struct fd_list*)n;
 			continue;
 		}

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -110,7 +110,7 @@ int fd_peer_add ( struct peer_info * info, const char * orig_dbg, void (*cb)(str
 	/* Create a structure to contain the new peer information */
 	CHECK_FCT( fd_peer_alloc(&p) );
 	
-	/* Copy the informations from the parameters received */
+	/* Copy the information from the parameters received */
 	p->p_hdr.info.pi_diamid = info->pi_diamid;
 	CHECK_FCT( fd_os_validate_DiameterIdentity(&p->p_hdr.info.pi_diamid, &p->p_hdr.info.pi_diamidlen, 1) );
 	

--- a/libfdcore/routing_dispatch.c
+++ b/libfdcore/routing_dispatch.c
@@ -287,7 +287,7 @@ static int score_destination_avp(void * cbdata, struct msg ** pmsg, struct fd_li
 			c->score += FD_SCORE_FINALDEST;
 		} else {
 			if (dr && !fd_os_almostcasesrch(dr->os.data, dr->os.len, c->realm, c->realmlen, NULL) ) {
-				/* The candidate's realm matchs the Destination-Realm */
+				/* The candidate's realm matches the Destination-Realm */
 				c->score += FD_SCORE_REALM;
 			}
 		}
@@ -779,7 +779,7 @@ static int msg_rt_in(struct msg * msg)
 			}
 
 			if (is_local_app == YES) {
-				/* Handle localy since we are able to */
+				/* Handle locally since we are able to */
 				fd_hook_call(HOOK_MESSAGE_ROUTING_LOCAL, msgptr, NULL, NULL, fd_msg_pmdl_get(msgptr));
 				CHECK_FCT(fd_fifo_post(fd_g_local, &msgptr) );
 				return 0;
@@ -804,7 +804,7 @@ static int msg_rt_in(struct msg * msg)
 		CHECK_FCT( fd_msg_source_get( qry, &qry_src, NULL ) );
 
 		if ((!qry_src) && (!is_err)) {
-			/* The message is a normal answer to a request issued localy, we do not call the callbacks chain on it. */
+			/* The message is a normal answer to a request issued locally, we do not call the callbacks chain on it. */
 			fd_hook_call(HOOK_MESSAGE_ROUTING_LOCAL, msgptr, NULL, NULL, fd_msg_pmdl_get(msgptr));
 			CHECK_FCT(fd_fifo_post(fd_g_local, &msgptr) );
 			return 0;
@@ -974,7 +974,7 @@ static int msg_rt_out(struct msg * msg)
 		CHECK_FCT( fd_msg_rt_associate ( msgptr, rtd ) );
 	}
 
-	/* Note: we reset the scores and pass the message to the callbacks, maybe we could re-use the saved scores when we have received an error ? -- TODO */
+	/* Note: we reset the scores and pass the message to the callbacks, maybe we could reuse the saved scores when we have received an error ? -- TODO */
 
 	/* Ok, we have our list in rtd now, let's (re)initialize the scores */
 	fd_rtd_candidate_extract(rtd, &candidates, FD_SCORE_INI);
@@ -1139,7 +1139,7 @@ fatal_error:
 	CHECK_FCT_DO(fd_core_shutdown(), );
 	
 end:	
-	; /* noop so that we get rid of "label at end of compund statement" warning */
+	; /* noop so that we get rid of "label at end of compound statement" warning */
 	/* Mark the thread as terminated */
 	pthread_cleanup_pop(1);
 	return NULL;

--- a/libfdcore/sctp.c
+++ b/libfdcore/sctp.c
@@ -39,7 +39,7 @@
 #include <netinet/sctp.h>
 #include <sys/uio.h>
 
-/* Size of buffer to receive ancilliary data. May need to be enlarged if more sockopt are set... */
+/* Size of buffer to receive ancillary data. May need to be enlarged if more sockopt are set... */
 #ifndef CMSG_BUF_LEN
 #define CMSG_BUF_LEN	1024
 #endif /* CMSG_BUF_LEN */
@@ -399,7 +399,7 @@ static int fd_setsockopt_prebind(int sk)
 		struct sctp_event_subscribe event;
 
 		memset(&event, 0, sizeof(event));
-		event.sctp_data_io_event	= 1;	/* to receive the stream ID in SCTP_SNDRCV ancilliary data on message reception */
+		event.sctp_data_io_event	= 1;	/* to receive the stream ID in SCTP_SNDRCV ancillary data on message reception */
 		event.sctp_association_event	= 0;	/* new or closed associations (mostly for one-to-many style sockets) */
 		event.sctp_address_event	= 1;	/* address changes */
 		event.sctp_send_failure_event	= 1;	/* delivery failures */
@@ -969,7 +969,7 @@ int fd_sctp_client( int *sock, int no_ip6, uint16_t port, struct fd_list * list,
 #else /* SCTP_CONNECTX_4_ARGS */
 	ret = sctp_connectx(*sock, sar.sa, count);
 #endif /* SCTP_CONNECTX_4_ARGS */
-	/* back to normal cancelation behabior */
+	/* back to normal cancellation behavior */
 	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
 	
 	if (ret < 0) {

--- a/libfdcore/sctp3436.c
+++ b/libfdcore/sctp3436.c
@@ -702,7 +702,7 @@ void fd_sctp3436_bye(struct cnxctx * conn)
 
 	CHECK_PARAMS_DO( conn && conn->cc_sctp3436_data.array, return );
 
-	/* End all TLS sessions, in series (not as efficient as paralel, but simpler) */
+	/* End all TLS sessions, in series (not as efficient as parallel, but simpler) */
 	for (i = 1; i < conn->cc_sctp_para.pairs; i++) {
 		if ( ! fd_cnx_teststate(conn, CC_STATUS_ERROR)) {
 			CHECK_GNUTLS_DO( gnutls_bye(conn->cc_sctp3436_data.array[i].session, GNUTLS_SHUT_WR), fd_cnx_markerror(conn) );

--- a/libfdcore/server.c
+++ b/libfdcore/server.c
@@ -53,7 +53,7 @@ struct server {
 
 	struct cnxctx *	conn;		/* server connection context (listening socket) */
 	int 		proto;		/* IPPROTO_TCP or IPPROTO_SCTP */
-	int 		secur;		/* TLS is started immediatly after connection ? 0: no; 1: RFU; 2: yes (TLS/TCP or TLS/SCTP) */
+	int 		secur;		/* TLS is started immediately after connection ? 0: no; 1: RFU; 2: yes (TLS/TCP or TLS/SCTP) */
 	
 	pthread_t	thr;		/* The thread waiting for new connections (will store the data in the clients fifo) */
 	enum s_state	state;		/* state of the thread */
@@ -349,7 +349,7 @@ int fd_servers_start()
 		ASSERT(0);
 #else /* DISABLE_SCTP */
 		
-		/* Create the server on unsecure port */
+		/* Create the server on insecure port */
 		if (fd_g_config->cnf_port) {
 			CHECK_MALLOC( s = new_serv(IPPROTO_SCTP, 0) );
 			CHECK_MALLOC( s->conn = fd_cnx_serv_sctp(fd_g_config->cnf_port, empty_conf_ep ? NULL : &fd_g_config->cnf_endpoints) );
@@ -445,7 +445,7 @@ int fd_servers_start()
 		}
 	}
 	
-	/* Now, if we had an empty list of local adresses (no address configured), try to read the real addresses from the kernel */
+	/* Now, if we had an empty list of local addresses (no address configured), try to read the real addresses from the kernel */
 	if (empty_conf_ep) {
 		CHECK_FCT(fd_cnx_get_local_eps(&fd_g_config->cnf_endpoints));
 		if (FD_IS_LIST_EMPTY(&fd_g_config->cnf_endpoints)) {

--- a/libfdproto/dictionary-internal.h
+++ b/libfdproto/dictionary-internal.h
@@ -90,8 +90,8 @@ struct dict_object {
 	 list[2]: sentinel for the type_enum list of this type, ordered by their constant value.
 
 	 => TYPE_ENUMS:
-	 list[0]: list of the contants for a given type, ordered by the constant name (fd_os_cmp). Sentinel is a (list[1]) element of a TYPE object.
-	 list[1]: list of the contants for a given type, ordered by the constant value. Sentinel is a (list[2]) element of a TYPE object.
+	 list[0]: list of the constants for a given type, ordered by the constant name (fd_os_cmp). Sentinel is a (list[1]) element of a TYPE object.
+	 list[1]: list of the constants for a given type, ordered by the constant value. Sentinel is a (list[2]) element of a TYPE object.
 	 list[2]: not used
 
 	 => AVPS:

--- a/libfdproto/dictionary.c
+++ b/libfdproto/dictionary.c
@@ -319,7 +319,7 @@ static void destroy_object(struct dict_object * obj)
 			/* unlink the element from the list */
 			fd_list_unlink( &obj->list[i] );
 		else
-			/* This is either a sentinel or unused (=emtpy) list, let's destroy it */
+			/* This is either a sentinel or unused (=empty) list, let's destroy it */
 			destroy_list( &obj->list[i] );
 	}
 
@@ -484,7 +484,7 @@ static int order_rule_by_avpvc ( struct dict_object *o1, struct dict_object *o2 
 /* The following macros assume that "what", "ret", "result" (variables), and "end" (label) exist
 in the local context where they are called. They are meant to be called only from the functions that follow. */
 
-/* For searchs of type "xxx_OF_xxx": children's parent or default parent */
+/* For searches of type "xxx_OF_xxx": children's parent or default parent */
 #define SEARCH_childs_parent( type_of_child, default_parent ) {			\
 	struct dict_object *__child = (struct dict_object *) what;		\
 	CHECK_PARAMS_DO( verify_object(__child) && 				\
@@ -632,7 +632,7 @@ in the local context where they are called. They are meant to be called only fro
 		ret = ENOENT;							\
 }
 
-/* For searchs of type "xxx_OF_xxx": if the search object is sentinel list for the "what" object */
+/* For searches of type "xxx_OF_xxx": if the search object is sentinel list for the "what" object */
 #define SEARCH_sentinel( type_of_what, what_list_nr, sentinel_list_nr ) {			\
 	struct dict_object *__what = (struct dict_object *) what;				\
 	CHECK_PARAMS_DO( verify_object(__what) && 						\
@@ -1945,8 +1945,8 @@ The parent is either struct dictionary * or struct dict_object *
 
 VENDOR_BY_ID : (parent = dictionary) returns list of vendors ordered by ID
 APPLICATION_BY_ID : (parent = dictionary) returns list of applications ordered by ID
-  ** for these two lists, the Vendor with id 0 and applciation with id 0 are excluded.
-     You must resolve them separatly with dict_search.
+  ** for these two lists, the Vendor with id 0 and application with id 0 are excluded.
+     You must resolve them separately with dict_search.
 
 TYPE_BY_NAME : (parent = dictionary) returns list of types ordered by name (osstring order)
 ENUMVAL_BY_NAME : (parent = type object) return list of constants for this type ordered by name (osstring order)

--- a/libfdproto/fifo.c
+++ b/libfdproto/fifo.c
@@ -63,7 +63,7 @@ struct fifo {
 	int		thrs_push; /* number of threads waitnig to push an item */
 
 	uint16_t	high;	/* High level threshold (see libfreeDiameter.h for details) */
-	uint16_t	low;	/* Low level threshhold */
+	uint16_t	low;	/* Low level threshold */
 	void 		*data;	/* Opaque pointer for threshold callbacks */
 	void		(*h_cb)(struct fifo *, void **); /* The callbacks */
 	void		(*l_cb)(struct fifo *, void **);
@@ -73,7 +73,7 @@ struct fifo {
 	long long	total_items;   /* Cumulated number of items that went through this fifo (excluding current count), always increasing. */
 	struct timespec total_time;    /* Cumulated time all items spent in this queue, including blocking time (always growing, use deltas for monitoring) */
 	struct timespec blocking_time; /* Cumulated time threads trying to post new items were blocked (queue full). */
-	struct timespec last_time;     /* For the last element retrieved from the queue, how long it take between posting (including blocking) and poping */
+	struct timespec last_time;     /* For the last element retrieved from the queue, how long it take between posting (including blocking) and popping */
 
 };
 
@@ -556,7 +556,7 @@ static __inline__ int test_l_cb(struct fifo * queue)
 	return 0;
 }
 
-/* Try poping an item */
+/* Try popping an item */
 int fd_fifo_tryget_int ( struct fifo * queue, void ** item )
 {
 	int wouldblock = 0;

--- a/libfdproto/log.c
+++ b/libfdproto/log.c
@@ -76,7 +76,7 @@ int fd_log_handler_register( void (*logger)(int loglevel, const char * format, v
 int fd_log_handler_unregister ( void )
 {
         fd_logger = fd_internal_logger;
-        return 0; /* Successfull in all cases. */
+        return 0; /* Successful in all cases. */
 }
 
 static void fd_cleanup_mutex_silent( void * mutex )

--- a/libfdproto/messages.c
+++ b/libfdproto/messages.c
@@ -349,7 +349,7 @@ int fd_msg_new_answer_from_req ( struct dictionary * dict, struct msg ** msg, in
 	/* Create the answer */
 	CHECK_FCT(  fd_msg_new( model, flags, &ans )  );
 	
-	/* Set informations in the answer as in the query */
+	/* Set information in the answer as in the query */
 	ans->msg_public.msg_code = qry->msg_public.msg_code; /* useful for MSGFL_ANSW_ERROR */
 	ans->msg_public.msg_appl = qry->msg_public.msg_appl;
 	ans->msg_public.msg_eteid = qry->msg_public.msg_eteid;
@@ -1092,7 +1092,7 @@ static DECLARE_FD_DUMP_PROTOTYPE( avp_format_summary, struct avp * avp, int leve
 	}
 	
 	if (!level) {
-		/* We have been called to explicitely dump this AVP, so we parse its name if available */
+		/* We have been called to explicitly dump this AVP, so we parse its name if available */
 		if (!avp->avp_model) {
 			name = "(no model)";
 		} else {
@@ -1392,7 +1392,7 @@ int fd_msg_source_set( struct msg * msg, DiamId_t diamid, size_t diamidlen )
 		return 0;
 	}
 	
-	/* Otherwise save the new informations */
+	/* Otherwise save the new information */
 	CHECK_MALLOC( msg->msg_src_id = os0dup(diamid, diamidlen) );
 	msg->msg_src_id_len = diamidlen;
 	/* done */
@@ -1455,7 +1455,7 @@ int fd_msg_source_get( struct msg * msg, DiamId_t* diamid, size_t * diamidlen )
 	CHECK_PARAMS( CHECK_MSG(msg) );
 	CHECK_PARAMS( diamid );
 	
-	/* Copy the informations */
+	/* Copy the information */
 	*diamid = msg->msg_src_id;
 	
 	if (diamidlen)
@@ -2417,7 +2417,7 @@ int fd_msg_parse_dict ( msg_or_avp * object, struct dictionary * dict, struct fd
 /***************************************************************************************************************/
 /* Parsing messages and AVP for rules (ABNF) compliance */
 
-/* This function is used to get stats (first occurence position, last occurence position, number of occurences) 
+/* This function is used to get stats (first occurrence position, last occurrence position, number of occurrences) 
    of AVP instances of a given model in a chain of AVP */
 static void parserules_stat_avps( struct dict_object * model_avp, struct fd_list *list, int * count, int * firstpos, int * lastpos) 
 {
@@ -2543,7 +2543,7 @@ static int parserules_check_one_rule(void * data, struct dict_rule_data *rule)
 			min = 1;
 	}
 	if (count < min) {
-		fd_log_error("Conflicting rule: the number of occurences (%d) is < the rule min (%d) for '%s'.", count, min, avp_name);
+		fd_log_error("Conflicting rule: the number of occurrences (%d) is < the rule min (%d) for '%s'.", count, min, avp_name);
 		if (pr_data->pei) {
 			pr_data->pei->pei_errcode = "DIAMETER_MISSING_AVP";
 			pr_data->pei->pei_avp = empty_avp(rule->rule_avp);
@@ -2554,7 +2554,7 @@ static int parserules_check_one_rule(void * data, struct dict_rule_data *rule)
 	
 	/* Check the "max" value */
 	if ((rule->rule_max != -1) && (count > rule->rule_max)) {
-		fd_log_error("Conflicting rule: the number of occurences (%d) is > the rule max (%d) for '%s'.", count, rule->rule_max, avp_name);
+		fd_log_error("Conflicting rule: the number of occurrences (%d) is > the rule max (%d) for '%s'.", count, rule->rule_max, avp_name);
 		if (pr_data->pei) {
 			if (rule->rule_max == 0)
 				pr_data->pei->pei_errcode = "DIAMETER_AVP_NOT_ALLOWED";
@@ -2707,7 +2707,7 @@ int fd_msg_parse_rules ( msg_or_avp * object, struct dictionary * dict, struct f
 
 /***************************************************************************************************************/
 
-/* Compute the lengh of an object and its subtree. */
+/* Compute the length of an object and its subtree. */
 int fd_msg_update_length ( msg_or_avp * object )
 {
 	size_t sz = 0;
@@ -2823,7 +2823,7 @@ int fd_msg_dispatch ( struct msg ** msg, struct session * session, enum disp_act
 
 	TEST_ACTION_STOP();
 	
-	/* If we don't know the model at this point, we stop cause we cannot get the dictionary. It's invalid: an error should already have been trigged by ANY callbacks */
+	/* If we don't know the model at this point, we stop cause we cannot get the dictionary. It's invalid: an error should already have been triggered by ANY callbacks */
 	CHECK_PARAMS_DO(cmd = (*msg)->msg_model, { ret = EINVAL; goto out; } );
 	
 	/* Now resolve message application */

--- a/libfdproto/rt_data.c
+++ b/libfdproto/rt_data.c
@@ -291,7 +291,7 @@ int  fd_rtd_candidate_reorder(struct fd_list * candidates)
 	TRACE_ENTRY("%p", candidates);
 	CHECK_PARAMS( candidates );
 	
-	/* First, move all items from candidates to the undordered list */
+	/* First, move all items from candidates to the unordered list */
 	fd_list_move_end(&unordered, candidates);
 	
 	/* Now extract each element from unordered and add it back to list ordered by score */

--- a/libfdproto/sessions.c
+++ b/libfdproto/sessions.c
@@ -191,7 +191,7 @@ static void * exp_fct(void * arg)
 again:
 		/* Check if there are expiring sessions available */
 		if (FD_IS_LIST_EMPTY(&exp_sentinel)) {
-			/* Just wait for a change or cancelation */
+			/* Just wait for a change or cancellation */
 			CHECK_POSIX_DO( pthread_cond_wait( &exp_cond, &exp_lock ), break /* this might not pop the cleanup handler, but since we ASSERT(0), it is not the big issue... */ );
 			/* Restart the loop on wakeup */
 			goto again;
@@ -679,7 +679,7 @@ int fd_sess_destroy ( struct session ** session )
 		free(st);
 	}
 
-	/* Finally, destroy the session itself, if it is not referrenced by any message anymore */
+	/* Finally, destroy the session itself, if it is not referenced by any message anymore */
 	if (destroy_now) {
 		del_session(sess);
 	} else {
@@ -705,9 +705,9 @@ int fd_sess_reclaim ( struct session ** session )
 
 	CHECK_POSIX( pthread_mutex_lock( H_LOCK(hash) ) );
 	pthread_cleanup_push( fd_cleanup_mutex, H_LOCK(hash) );
-	CHECK_POSIX_DO( pthread_mutex_lock( &sess->stlock ), { ASSERT(0); /* otherwise, cleanup not poped on FreeBSD */ } );
+	CHECK_POSIX_DO( pthread_mutex_lock( &sess->stlock ), { ASSERT(0); /* otherwise, cleanup not popped on FreeBSD */ } );
 	pthread_cleanup_push( fd_cleanup_mutex, &sess->stlock );
-	CHECK_POSIX_DO( pthread_mutex_lock( &exp_lock ), { ASSERT(0); /* otherwise, cleanup not poped on FreeBSD */ } );
+	CHECK_POSIX_DO( pthread_mutex_lock( &exp_lock ), { ASSERT(0); /* otherwise, cleanup not popped on FreeBSD */ } );
 	pthread_cleanup_push( fd_cleanup_mutex, &exp_lock );
 
 	/* We only do something if the states list is empty */
@@ -724,9 +724,9 @@ int fd_sess_reclaim ( struct session ** session )
 	}
 
 	pthread_cleanup_pop(0);
-	CHECK_POSIX_DO( pthread_mutex_unlock( &exp_lock ), { ASSERT(0); /* otherwise, cleanup not poped on FreeBSD */ } );
+	CHECK_POSIX_DO( pthread_mutex_unlock( &exp_lock ), { ASSERT(0); /* otherwise, cleanup not popped on FreeBSD */ } );
 	pthread_cleanup_pop(0);
-	CHECK_POSIX_DO( pthread_mutex_unlock( &sess->stlock ), { ASSERT(0); /* otherwise, cleanup not poped on FreeBSD */ } );
+	CHECK_POSIX_DO( pthread_mutex_unlock( &sess->stlock ), { ASSERT(0); /* otherwise, cleanup not popped on FreeBSD */ } );
 	pthread_cleanup_pop(0);
 	CHECK_POSIX( pthread_mutex_unlock( H_LOCK(hash) ) );
 

--- a/tests/testfifo.c
+++ b/tests/testfifo.c
@@ -101,7 +101,7 @@ static struct thrh_test {
 	int		l_calls; /* number of calls of l_cb */
 } thrh_td;
 
-/* Callbacks for threasholds test */
+/* Callbacks for thresholds test */
 void thrh_cb_h(struct fifo *queue, void **data)
 {
 	if (thrh_td.h_calls == thrh_td.l_calls) {
@@ -373,7 +373,7 @@ int main(int argc, char *argv[])
 		}
 	}
 	
-	/* Test thread cancelation */
+	/* Test thread cancellation */
 	{
 		struct fifo      	*queue = NULL;
 		pthread_barrier_t	 bar;
@@ -441,7 +441,7 @@ int main(int argc, char *argv[])
 		CHECK( 0, fd_fifo_del(&queue) );
 	}
 	
-	/* Test the threashold function */
+	/* Test the threshold function */
 	{
 		struct fifo * queue = NULL;
 		int i;
@@ -472,7 +472,7 @@ int main(int argc, char *argv[])
 		CHECK( 0, thrh_td.h_calls );
 		CHECK( 0, thrh_td.l_calls );
 		
-		/* Now, post 6 messages, the high threashold */
+		/* Now, post 6 messages, the high threshold */
 		for (i=0; i<6; i++) {
 			msg = msg1;
 			CHECK( 0, fd_fifo_post(queue, &msg) );

--- a/tests/testmesg.c
+++ b/tests/testmesg.c
@@ -353,7 +353,7 @@ int main(int argc, char *argv[])
 		
 		CHECK( 0, fd_dict_search ( fd_g_config->cnf_dict, DICT_COMMAND, CMD_BY_NAME, "Test-Command-Request", &cmd_model, ENOENT ) );
 		
-		/* Check an error is trigged if the AVP has no value set */
+		/* Check an error is triggered if the AVP has no value set */
 		{
 			CHECK( 0, fd_dict_search ( fd_g_config->cnf_dict, DICT_AVP,     AVP_BY_NAME,     "AVP Test - no vendor - f32", &avp_model, ENOENT ) );
 			
@@ -1424,7 +1424,7 @@ int main(int argc, char *argv[])
 			
 			/* 120 ~ 127 : next header */
 			CHECK( 0x0c, buf[127] ); /* (the size) */
-			CHECK( 0x4a, buf[128]); /* http://en.wikipedia.org/wiki/IEEE_754-1985 to get descvription of the format */
+			CHECK( 0x4a, buf[128]); /* http://en.wikipedia.org/wiki/IEEE_754-1985 to get description of the format */
 			CHECK( 0x00, buf[129]); /* v = 2097153 = 2^21 + 2 ^ 0; sign : "+", 2^21 <= v < 2^22 => exponent = 21; biaised on 8 bits => 21 + 127 => 100 1010 0 */
 			CHECK( 0x00, buf[130]); /* v = (+1) * (1 ^ 21) * ( 1 + 2^-21 ) => significand 000 0000 0000 0000 0000 0100 */
 			CHECK( 0x04, buf[131]); /* result: 4a 00 00 04 */

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -123,7 +123,7 @@ static void * signal_catch(void * arg)
 	/* Unblock any other signal for this thread, so that default handler is enabled */
 	CHECK_SYS_DO( pthread_sigmask( SIG_SETMASK, &ss, NULL ), );
 	
-	/* Now wait for sigwait or cancelation */
+	/* Now wait for sigwait or cancellation */
 	CHECK_POSIX_DO( sigwait(&ss, &sig),  );
 	FAILTEST("The timeout (" _stringize(TEST_TIMEOUT) " sec) was reached. Use -n or change TEST_TIMEOUT if the test needs more time to execute.");
 	


### PR DESCRIPTION
The vast majority of them occur in code comments.
Some of them occur in messages seen by end-users.