### PR TITLE
Reconnect to DB

### DIFF
--- a/extensions/app_acct/acct_db.c
+++ b/extensions/app_acct/acct_db.c
@@ -250,6 +250,7 @@ int acct_db_insert(struct acct_record_list * records)
 	if (PQstatus(conn) != CONNECTION_OK) {
 		/* Attempt a reset */
 		PQreset(conn);
+		new = 1;
 		if (PQstatus(conn) != CONNECTION_OK) {
 			TRACE_DEBUG(INFO, "Lost connection to the database server, and attempt to reestablish it failed");
 			TODO("Terminate the freeDiameter instance completely?");


### PR DESCRIPTION
allow reconnecting after the postgres database is restarted, for example during a upgrade or other maintenance, or crash.

Otherwise the prepared statement is not found.