### PR TITLE
Handle non-toplevel AVPs

### DIFF
--- a/extensions/app_acct/acct_records.c
+++ b/extensions/app_acct/acct_records.c
@@ -109,7 +109,7 @@ int acct_rec_map(struct acct_record_list * records, struct msg * msg)
 		}
 		
 		/* Go to next AVP in the message */
-		CHECK_FCT( fd_msg_browse(avp, MSG_BRW_NEXT, &avp, NULL) );
+		CHECK_FCT( fd_msg_browse(avp, MSG_BRW_WALK, &avp, NULL) );
 	}
 	
 	/* Done */


### PR DESCRIPTION
This change allows storing to the database any primitive element from a grouped AVP, which are currently not handled by app_acct.