### PR TITLE
feature: now the dictionary sees the differences between the commands…

### DIFF
--- a/include/freeDiameter/libfdproto.h
+++ b/include/freeDiameter/libfdproto.h
@@ -1647,12 +1647,20 @@ struct dict_cmd_data {
 	uint8_t		 cmd_flag_val;	/* values of the fixed flags */
 };
 
+/* Structure for querying the dictionary about a command */
+struct dict_cmd_request {
+	command_code_t cmd_code;
+	application_id_t app_id;
+};
+
 /* The criteria for searching an avp object in the dictionary */
 enum {
 	CMD_BY_NAME = 60,	/* "what" points to a char * */
 	CMD_BY_CODE_R,		/* "what" points to a command_code_t. The "Request" command is returned. */
 	CMD_BY_CODE_A,		/* "what" points to a command_code_t. The "Answer" command is returned. */
-	CMD_ANSWER		/* "what" points to a struct dict_object of a request command. The corresponding "Answer" command is returned. */
+	CMD_ANSWER,		    /* "what" points to a struct dict_object of a request command. The corresponding "Answer" command is returned. */
+	CMD_BY_CODE_R_APPL_ID,	/* "what" points to a struct dict_cmd_request. The "Request" command is returned. */
+	CMD_BY_CODE_A_APPL_ID,	/* "what" points to a struct dict_cmd_request. The "Answer" command is returned. */
 };
 
 


### PR DESCRIPTION
This update allows to create messages with the same code and different application IDs.
For example, the CCR message in the DCCA and 3gp Gx application. Both types of messages in my case should be used in the same instance of freeDiameter. However, these messages have a different contradictory set of rules. In the past, I had to break down a set of rules to make it suitable for both types of messages, otherwise, dispatcher would not skip them, interrupting processing during checking and parsing messages. After my edits, both types of messages can exist in the same instance of freeDiameter. it is very comfortable. and I've wanted to do it for a long time and now I've done it.