### PR TITLE
Deb packages on Ubuntu 22.04

### DIFF
--- a/INSTALL.Ubuntu
+++ b/INSTALL.Ubuntu
@@ -47,7 +47,7 @@ the following commands should generate the freeDiameter packages for you:
 sudo apt-get -y install git cmake make gcc g++ bison flex libsctp-dev libgnutls-dev libgcrypt-dev libidn2-dev ssl-cert debhelper fakeroot \
    libpq-dev libmysqlclient-dev libxml2-dev swig python-dev libjsoncpp-dev
 
-# On latest Ubuntu you will need libgnutls28-dev instead of libgnutls-dev
+# On latest Ubuntu you will need libgnutls28-dev instead of libgnutls-dev and python2-dev instead of python-dev
 
 # Retrieve the latest version of the source package
 cd

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -4,8 +4,8 @@ Priority: extra
 Maintainer: Sebastien Decugis <sdecugis@freediameter.net>
 Build-Depends: debhelper ( >= 7.3.9),
  cmake, make, gcc, g++, bison, flex,
- libsctp-dev, libgnutls-dev | gnutls-dev, libidn2-dev,
- libpq-dev, libmysqlclient-dev, libxml2-dev, swig, python-dev,
+ libsctp-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, libidn2-dev,
+ libpq-dev, libmysqlclient-dev, libxml2-dev, swig, python2-dev | python-dev,
  libgcrypt11-dev | libgcrypt20-dev
 Standards-Version: 3.8.3
 Homepage: http://www.freediameter.net

--- a/extensions/app_diameap/diameap.c
+++ b/extensions/app_diameap/diameap.c
@@ -43,6 +43,9 @@
 static struct diameap_conf conf;
 struct diameap_conf * diameap_config = &conf;
 
+MYSQL *db_conn;
+boolean check_user_identity;
+
 /* The entry point */
 static int diameap_main(char * conffile)
 {

--- a/extensions/app_diameap/diameap_mysql.h
+++ b/extensions/app_diameap/diameap_mysql.h
@@ -43,7 +43,7 @@
 #include <mysql.h>
 
 /* MySQL Database connection */
-MYSQL *db_conn;
+extern MYSQL *db_conn;
 
 int diameap_get_eap_user(struct eap_user * user, char * username);
 

--- a/extensions/app_diameap/diameap_user.h
+++ b/extensions/app_diameap/diameap_user.h
@@ -73,7 +73,7 @@ struct eap_user
 	boolean success; /* Set to TRUE if User is authenticated successfully */
 };
 
-boolean check_user_identity;
+extern boolean check_user_identity;
 
 int diameap_user_get_password(struct eap_user *user, u8 * password,u16 *length);
 

--- a/extensions/app_diameap/plugins/eap_tls/eap_tls.c
+++ b/extensions/app_diameap/plugins/eap_tls/eap_tls.c
@@ -38,6 +38,8 @@
 
 #include "eap_tls.h"
 
+struct tls_config    tls_global_conf;
+
 __attribute__((visibility("default")))
 int eap_tls_configure(char * configfile);
 

--- a/extensions/app_diameap/plugins/eap_tls/eap_tls.h
+++ b/extensions/app_diameap/plugins/eap_tls/eap_tls.h
@@ -40,7 +40,7 @@
 
 #include "../../plugins.h"
 
-struct tls_config	tls_global_conf;
+extern struct tls_config	tls_global_conf;
 
 int diameap_eap_tls_buildReq_ack(u8 id, struct eap_packet * eapPacket);
 int diameap_eap_tls_buildReq_start(u8 id, struct eap_packet * eapPacket);


### PR DESCRIPTION
Building of deb packages on Ubuntu 22.04 is failing because of incorrect build dependencies and because there are several `multiple definition` errors in `diameap` extension.

```
    /usr/bin/ld: CMakeFiles/app_diameap.dir/lex.diameap.c.o:/home/user/freeDiameter/extensions/app_diameap/diameap_mysql.h:46: multiple definition of `db_conn'; CMakeFiles/app_diameap.dir/diameap.tab.c.o:/home/user/freeDiameter/extensions/app_diameap/diameap_mysql.h:46: first defined here
    /usr/bin/ld: CMakeFiles/app_diameap.dir/lex.diameap.c.o:/home/user/freeDiameter/extensions/app_diameap/diameap_user.h:76: multiple definition of `check_user_identity'; CMakeFiles/app_diameap.dir/diameap.tab.c.o:/home/user/freeDiameter/extensions/app_diameap/diameap_user.h:76: first defined here

    /usr/bin/ld: CMakeFiles/eap_tls.dir/lex.eaptls.c.o:/home/user/freeDiameter/extensions/app_diameap/plugins/eap_tls/eap_tls.h:43: multiple definition of `tls_global_conf'; CMakeFiles/eap_tls.dir/eap_tls.c.o:/home/user/freeDiameter/extensions/app_diameap/plugins/eap_tls/eap_tls.h:43: first defined here
    /usr/bin/ld: CMakeFiles/eap_tls.dir/eaptls.tab.c.o:/home/user/freeDiameter/extensions/app_diameap/plugins/eap_tls/eap_tls.h:43: multiple definition of `tls_global_conf'; CMakeFiles/eap_tls.dir/eap_tls.c.o:/home/user/freeDiameter/extensions/app_diameap/plugins/eap_tls/eap_tls.h:43: first defined here
```