### PR TITLE
Allow loopback, link-local, and site-local endpoint IP addresses

### DIFF
--- a/libfdcore/endpoints.c
+++ b/libfdcore/endpoints.c
@@ -64,7 +64,6 @@ int fd_ep_add_merge( struct fd_list * list, sSA * sa, socklen_t sl, uint32_t fla
 		case AF_INET:
 			if (! (flags & EP_ACCEPTALL)) {
 				if (IN_IS_ADDR_UNSPECIFIED(&ptr.sin->sin_addr) 
-				 || IN_IS_ADDR_LOOPBACK(&ptr.sin->sin_addr)
 				    /* the next one filters both EXPERIMENTAL, BADCLASS and MULTICAST. */
 				 || ((ntohl(ptr.sin->sin_addr.s_addr) & 0xe0000000) == 0xe0000000)
 				 || (ptr.sin->sin_addr.s_addr == INADDR_BROADCAST)) {
@@ -78,10 +77,7 @@ int fd_ep_add_merge( struct fd_list * list, sSA * sa, socklen_t sl, uint32_t fla
 		case AF_INET6:
 			if (! (flags & EP_ACCEPTALL)) {
 				if (IN6_IS_ADDR_UNSPECIFIED(&ptr.sin6->sin6_addr) 
-				 || IN6_IS_ADDR_LOOPBACK(&ptr.sin6->sin6_addr)
-				 || IN6_IS_ADDR_MULTICAST(&ptr.sin6->sin6_addr)
-				 || IN6_IS_ADDR_LINKLOCAL(&ptr.sin6->sin6_addr)
-				 || IN6_IS_ADDR_SITELOCAL(&ptr.sin6->sin6_addr)) {
+				 || IN6_IS_ADDR_MULTICAST(&ptr.sin6->sin6_addr)) {
 					LOG_A("  DEBUG:fd_ep_add_merge  Address was ignored, not added.");
 					return 0;
 				}


### PR DESCRIPTION
They're valid addresses, and if you want to run a couple local services (eg, Open5gs) it's easier to use loopback addresses than to dynamically mess with the configuration to update for whatever IP address your interface has now.